### PR TITLE
Fix double counting of successful paired reads

### DIFF
--- a/ci/test_fastq_from_aviti_one_run/tests/test_sci_dash.py
+++ b/ci/test_fastq_from_aviti_one_run/tests/test_sci_dash.py
@@ -22,6 +22,18 @@ def test_sci_dash_data():
     assert data["n_uncorrectable_rt"] == 78664
     assert data["n_hashing"] == 370
 
+    # check self-consistency of success counts
+    sum_sample_success = sum(v["n_pairs_success"] for v in data["sample_success"].values())
+    sum_p5_success_counts = sum(d["frequency"] for d in data["p5_index_counts"])
+    sum_p7_success_counts = sum(d["frequency"] for d in data["p7_index_counts"])
+    sum_ligation_success_counts = sum(d["frequency"] for d in data["ligation_barcode_counts"])
+    sum_rt_success_counts = sum(d["frequency"] for k in data["rt_barcode_counts"].values() for d in k)
+    assert sum_sample_success == data["n_pairs_success"]
+    assert sum_p5_success_counts == data["n_pairs_success"]
+    assert sum_p7_success_counts == data["n_pairs_success"]
+    assert sum_ligation_success_counts == data["n_pairs_success"]
+    assert sum_rt_success_counts == data["n_pairs_success"]
+
     assert "ZAe-10hpf-28" in data["sample_success"]
     assert "ZAe-14hpf-28" in data["sample_success"]
 

--- a/workflow/rules/scripts/demultiplexing/demux_rocket.py
+++ b/workflow/rules/scripts/demultiplexing/demux_rocket.py
@@ -215,14 +215,6 @@ def update_qc(qc:dict, x:sciRecord):
         qc["p7_index_counts"][x.p7_name] += 1
         qc["ligation_barcode_counts"][x.ligation_name] += 1
 
-        # Keep track of correct read-pairs per sample.
-        qc["sample_success"][x.sample_name]["n_pairs_success"] += 1
-
-        # Count the occurence of the barcodes.
-        qc["p5_index_counts"][x.p5_name] += 1
-        qc["p7_index_counts"][x.p7_name] += 1
-        qc["ligation_barcode_counts"][x.ligation_name] += 1
-
         # Count the occurence of the RT barcodes (per plate).
         plate_well, plate_index = x.rt_name.split("-")
 


### PR DESCRIPTION
- remove duplicate code resulting in double-counting of some successful read counts
- add self-consistency tests of successful read counts which pass with these changes
- resolves #29