### PR TITLE
Replace `path_fastq` and `path_bcl` with `path_reads` in sample sheet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-      - run: pip install pytest
+      - run: pip install pytest pandas
+      - name: Unit tests
+        run: pytest tests/unit -vvv
       - name: Download test data
-        run: mkdir -p tests/data && wget -O - https://github.com/lauren-saunders-lab/sci-rocket-test-data/releases/download/2026.01.08/test-data.tgz | tar -xvzf - -C tests/data
+        run: mkdir -p tests/data && wget -O - https://github.com/lauren-saunders-lab/sci-rocket-test-data/releases/download/2026.01.09/test-data.tgz | tar -xvzf - -C tests/data
       - name: Run workflow test_bcl_one_run
         uses: snakemake/snakemake-github-action@v2
         with:

--- a/tests/test_bcl_two_runs/samplesheet.tsv
+++ b/tests/test_bcl_two_runs/samplesheet.tsv
@@ -1,3 +1,3 @@
-path_bcl	experiment_name	p5	p7	rt	sample_name	species	n_expected_cells	hashing
+path_reads	experiment_name	p5	p7	rt	sample_name	species	n_expected_cells	hashing
 ../data/reads/bcl/two_runs/run1	zfish	A03:H03	C01:C12	"P01-A01:P01-A07,P01-B01:P01-B07,P01-C01:P01-C07,P01-D01:P01-D07,P01-E01:P01-E07,P01-F01:P01-F07,P01-G01:P01-G07,P01-H01:P01-H07"	zfish-hash	Zebrafish	34000	../hash.tsv
-../data/reads/bcl/two_runs/run2	zfish	A03:H03	C01:C12	"P01-A01:P01-A07,P01-B01:P01-B07,P01-C01:P01-C07,P01-D01:P01-D07,P01-E01:P01-E07,P01-F01:P01-F07,P01-G01:P01-G07,P01-H01:P01-H07"	zfish-hash	Zebrafish	34000	../hash.tsv
+../data/reads/bcl/two_runs/run2/	zfish	A03:H03	C01:C12	"P01-A01:P01-A07,P01-B01:P01-B07,P01-C01:P01-C07,P01-D01:P01-D07,P01-E01:P01-E07,P01-F01:P01-F07,P01-G01:P01-G07,P01-H01:P01-H07"	zfish-hash	Zebrafish	34000	../hash.tsv

--- a/tests/test_fastq_from_aviti_two_runs/samplesheet.tsv
+++ b/tests/test_fastq_from_aviti_two_runs/samplesheet.tsv
@@ -1,4 +1,4 @@
-path_fastq	experiment_name	p5	p7	rt	sample_name	species	n_expected_cells	hashing
+path_reads	experiment_name	p5	p7	rt	sample_name	species	n_expected_cells	hashing
 ../data/reads/fastq_from_aviti/two_runs/run1	Drer.ZAe	A03:H03	D01:D12	P01-D07:P01-H07	ZAe-10hpf-28	Zebrafish	14421 	../hash.tsv
 ../data/reads/fastq_from_aviti/two_runs/run1	Drer.ZAe	A03:H03	D01:D12	P01-A08:P01-H08	ZAe-10hpf-28	Zebrafish	14421 	../hash.tsv
 ../data/reads/fastq_from_aviti/two_runs/run1	Drer.ZAe	A03:H03	D01:D12	P01-A09:P01-E09	ZAe-10hpf-28	Zebrafish	14421	../hash.tsv

--- a/tests/test_fastq_from_bcl_one_run/samplesheet.tsv
+++ b/tests/test_fastq_from_bcl_one_run/samplesheet.tsv
@@ -1,2 +1,2 @@
-path_fastq	experiment_name	p5	p7	rt	sample_name	species	n_expected_cells	hashing
-../data/reads/fastq_from_bcl/one_run/run1	zfish	A03:H03	C01:C12	"P01-A01:P01-A07,P01-B01:P01-B07,P01-C01:P01-C07,P01-D01:P01-D07,P01-E01:P01-E07,P01-F01:P01-F07,P01-G01:P01-G07,P01-H01:P01-H07"	zfish-hash	Zebrafish	34000	../hash.tsv
+path_reads	experiment_name	p5	p7	rt	sample_name	species	n_expected_cells	hashing
+../data/reads/fastq_from_bcl/one_run/run1/	zfish	A03:H03	C01:C12	"P01-A01:P01-A07,P01-B01:P01-B07,P01-C01:P01-C07,P01-D01:P01-D07,P01-E01:P01-E07,P01-F01:P01-F07,P01-G01:P01-G07,P01-H01:P01-H07"	zfish-hash	Zebrafish	34000	../hash.tsv

--- a/tests/test_fastq_from_bcl_two_runs/samplesheet.tsv
+++ b/tests/test_fastq_from_bcl_two_runs/samplesheet.tsv
@@ -1,3 +1,3 @@
-path_fastq	experiment_name	p5	p7	rt	sample_name	species	n_expected_cells	hashing
-../data/reads/fastq_from_bcl/two_runs/run1	zfish	A03:H03	C01:C12	"P01-A01:P01-A07,P01-B01:P01-B07,P01-C01:P01-C07,P01-D01:P01-D07,P01-E01:P01-E07,P01-F01:P01-F07,P01-G01:P01-G07,P01-H01:P01-H07"	zfish-hash	Zebrafish	34000	../hash.tsv
+path_reads	experiment_name	p5	p7	rt	sample_name	species	n_expected_cells	hashing
+../data/reads/fastq_from_bcl/two_runs/run1/	zfish	A03:H03	C01:C12	"P01-A01:P01-A07,P01-B01:P01-B07,P01-C01:P01-C07,P01-D01:P01-D07,P01-E01:P01-E07,P01-F01:P01-F07,P01-G01:P01-G07,P01-H01:P01-H07"	zfish-hash	Zebrafish	34000	../hash.tsv
 ../data/reads/fastq_from_bcl/two_runs/run2	zfish	A03:H03	C01:C12	"P01-A01:P01-A07,P01-B01:P01-B07,P01-C01:P01-C07,P01-D01:P01-D07,P01-E01:P01-E07,P01-F01:P01-F07,P01-G01:P01-G07,P01-H01:P01-H07"	zfish-hash	Zebrafish	34000	../hash.tsv

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Add the root directory of the project to sys.path to allow imports from top-level workflow folder
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))

--- a/tests/unit/demultiplexing/test_preprocess.py
+++ b/tests/unit/demultiplexing/test_preprocess.py
@@ -1,0 +1,51 @@
+import pytest
+import pathlib
+import workflow.rules.scripts.demultiplexing.preprocess as preprocess
+
+
+def write_tsv(path, header, rows):
+    pathlib.Path(path).write_text("\t".join(header) + "\n" + "\n".join("\t".join(map(str, r)) for r in rows) + "\n")
+
+
+@pytest.fixture
+def test_config(tmp_path) -> dict:
+    # Minimal samplesheet
+    samples_path = tmp_path / "samples.tsv"
+    write_tsv(samples_path,
+              header=["path_reads", "experiment_name", "p5", "p7", "rt", "sample_name", "species", "n_expected_cells"],
+              rows=[["run", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "sample1", "mouse", "10000"]])
+
+    # Minimal barcodes file
+    barcodes_path = tmp_path / "barcodes.tsv"
+    write_tsv(barcodes_path, header=["type", "barcode", "sequence"],
+              rows=[["ligation", "LIG1", "ACTTGATTGT"],
+                    ["p5", "A01", "CGTTCTATCA"],
+                    ["p7", "A01", "CTAAGCCTTG"],
+                    ["rt", "P01-B02", "GCCGCAACGA"],
+                    ])
+
+    return {"path_samples": str(samples_path),
+            "path_barcodes": str(barcodes_path),
+            "species": {"mouse": {"genome": "", "genome_gtf": "", "star_index": ""}}}
+
+
+def test_get_samples_deduplicated_sequencing_names(test_config: dict):
+    write_tsv(test_config["path_samples"],
+              header=["path_reads", "experiment_name", "p5", "p7", "rt", "sample_name", "species", "n_expected_cells"],
+              rows=[
+                  ["/path/r1", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "sample1", "mouse", "10000"],
+                  ["/other/r1", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "sample2", "mouse", "10000"],
+                  ["/path/r1", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "sample3", "mouse", "10000"],
+                  ["/x/r1", "exp2", "A02:H02", "H01:H12", "P01-A01:P01-D12", "sample4", "mouse", "10000"],
+                  ["/other/r2", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "sample5", "mouse", "10000"],
+                  ["/path/r1", "exp2", "A02:H02", "H01:H12", "P01-A01:P01-D12", "sample6", "mouse", "10000"],
+                  ["/other/r1", "exp", "A01:B01", "H06:H12", "P01-A01:P01-D12", "sample7", "mouse", "10000"],
+              ], )
+    samples = preprocess.get_samples(test_config)
+    assert samples["sequencing_name"][0] == "r1"  # exp/r1: first r1 in exp, so ok as is
+    assert samples["sequencing_name"][1] == "r1_1"  # exp/r1_1: second r1 in exp & has different path (/other/r1) to first one, so renamed
+    assert samples["sequencing_name"][2] == "r1"  # exp/r1: repeat of first r1 path in exp, so ok as is
+    assert samples["sequencing_name"][3] == "r1"  # exp2/r1: different experiment, so ok as is
+    assert samples["sequencing_name"][4] == "r2"  # exp/r2: first r2 in exp, so ok as is
+    assert samples["sequencing_name"][5] == "r1_1"  # exp2/r1_1: second r1 in exp2 with different path, so renamed
+    assert samples["sequencing_name"][6] == "r1_1"  # exp1/r1_1: same path & exp as sample 2

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -53,7 +53,7 @@ rule all:
 # Load rules ----
 
 
-include: "rules/step1_bcl2fastq.smk"
+include: "rules/step1_reads2fastq.smk"
 include: "rules/step2_demultiplexing_fastq.smk"
 include: "rules/step3_alignment.smk"
 include: "rules/step4_dashboard.smk"

--- a/workflow/examples/example_samplesheet.tsv
+++ b/workflow/examples/example_samplesheet.tsv
@@ -1,3 +1,3 @@
-path_bcl	experiment_name	p5	p7	rt	sample_name	species	n_expected_cells
+path_reads	experiment_name	p5	p7	rt	sample_name	species	n_expected_cells
 /bcl/230316_VH00211_239_AACK2K3M5/	testRun	A02:H02,A03:D03	H01:H12,G02:G04	P01-A01:P01-D12,P02-A01:P02-B12	sample1	mouse	10000
 /bcl/230316_VH00211_239_AACK2K3M5/	testRun	A02:H02	H01:H12,G02:G04	P01-A02	sample2	mouse	10000

--- a/workflow/rules/scripts/demultiplexing/preprocess.py
+++ b/workflow/rules/scripts/demultiplexing/preprocess.py
@@ -133,9 +133,9 @@ def sanity_samples(log, samples, barcodes, config):
         log.error("Sanity check (Sample sheet) - Missing required column(s): {}".format(", ".join(required_columns.difference(samples.columns))))
         return False
     
-    # Check if path_bcl or path_fastq exist in the sample sheet.
-    if "path_bcl" not in samples.columns and "path_fastq" not in samples.columns:
-        log.error("Sanity check (Sample sheet) - Missing either path_bcl or path_fastq column.")
+    # Check if path, path_bcl or path_fastq exist in the sample sheet.
+    if "path_reads" not in samples.columns and "path_bcl" not in samples.columns and "path_fastq" not in samples.columns:
+        log.error("Sanity check (Sample sheet) - Missing 'path' (or 'path_bcl' or 'path_fastq') column.")
         return False
 
     # Check if the sample sheet contains species which are not defined in the config.
@@ -301,22 +301,31 @@ def get_samples(config: dict) -> pd.DataFrame:
     # Perform sanity checks.
     check_sanity(samples, barcodes, config)
 
-    ## Generate the sequencing_name based on the last folder name of the path_bcl or path_fastq.
     if "path_fastq" in samples.columns and "path_bcl" in samples.columns:
         print("Both BCL and FASTQ paths are specified in the samples file. Will start from FASTQ.")
 
-    if "path_fastq" in samples.columns:
-        samples["path_fastq"] = samples["path_fastq"].str.rstrip("/")
-        samples["path_bcl"] = samples["path_fastq"]
-        samples["sequencing_name"] = samples["path_fastq"].str.split("/").str[-1]
-    elif "path_bcl" in samples.columns:
-        samples["path_bcl"] = samples["path_bcl"].str.rstrip("/")
-        samples["sequencing_name"] = samples["path_bcl"].str.split("/").str[-1]
-    else:
-        raise ValueError("Either path_bcl or path_fastq must be specified in the samples file.")
+    # If 'path_reads' column is not provided, use 'path_bcl' or 'path_fastq' column as 'path_reads'.
+    if "path_reads" not in samples.columns:
+        for col in ["path_bcl", "path_fastq"]:
+            if col in samples.columns:
+                samples["path_reads"] = samples[col]
+                samples.drop(col, axis=1, inplace=True)
+    samples["path_reads"] = samples["path_reads"].str.rstrip("/")
 
-    # Select unique samples for which to generate sample-specific files.
-    return samples.drop_duplicates(subset=["path_bcl", "sequencing_name", "experiment_name", "sample_name", "species"])
+    # Drop duplicate rows based on experiment_name, sample_name, species and path.
+    samples.drop_duplicates(subset=["path_reads", "experiment_name", "sample_name", "species"], inplace=True)
+
+    # Generate the sequencing_name based on the last folder name of the path
+    sequencing_name = samples["path_reads"].str.split("/").str[-1]
+    # Append a counter to sequencing_name in case of duplicates with differing paths within the same experiment.
+    # This avoids overwriting data for samples with different paths but same sequencing_name within the same experiment.
+    path_id = (
+        samples.groupby(["experiment_name", sequencing_name])["path_reads"]
+        .transform(lambda s: pd.factorize(s)[0])
+    )
+    samples["sequencing_name"] = sequencing_name + path_id.where(path_id.eq(0), "_" + path_id.astype(str)).replace(0, "")
+
+    return samples
 
 
 def get_haplotyping_samples(samples_unique: pd.DataFrame) -> pd.DataFrame:

--- a/workflow/rules/step1_reads2fastq.smk
+++ b/workflow/rules/step1_reads2fastq.smk
@@ -1,31 +1,17 @@
-#   * Convert BCL files to Undetermined.fastq.gz files with p5+p7 in the read-name. *
+#   * Convert reads to Undetermined.fastq.gz files with p5+p7 in the read-name. *
 #
 #   1. make_fake_samplesheet:       Generate fake sample-sheet to allow indexes to be added to R1/R2.
-#   2. bcl2fastq:                   Convert bcl to fastq with p5 and p7 indexes within the read name.
+#   2. reads2fastq:                   Convert bcl to fastq with p5 and p7 indexes within the read name.
 #############
 
 from pathlib import Path
 
 
-def get_bcl2fastq_input(sequencing_name, experiment_name):
+def get_path(sequencing_name, experiment_name):
     """
-    Return the path to the bcl file for a given sequencing run.
+    Return the path to the reads for a given sequencing run.
     """
-    return samples_unique.query("sequencing_name == @sequencing_name & experiment_name == @experiment_name").path_bcl.values[0]
-
-
-def get_folder_undetermined(sequencing_name, experiment_name):
-    """
-    Return the path to the folder containing the Undetermined fastq files (R1 and R2) for a given sequencing run from the samplesheet (path_fastq)
-    """
-    if "path_fastq" not in samples_unique.columns:
-        return ""
-    else:
-        if samples_unique.query("sequencing_name == @sequencing_name & experiment_name == @experiment_name").path_fastq.values[0] == "None":
-            return ""
-        else:
-            # If yes, then use the path from the samplesheet as an absolute path for symlinking
-            return str(Path(samples_unique.query("sequencing_name == @sequencing_name & experiment_name == @experiment_name").path_fastq.values[0]).resolve())
+    return samples_unique.query("sequencing_name == @sequencing_name & experiment_name == @experiment_name").path_reads.values[0]
 
 
 rule make_fake_samplesheet:
@@ -42,9 +28,9 @@ rule make_fake_samplesheet:
         """
 
 
-rule bcl2fastq:
+rule reads2fastq:
     input:
-        path_bcl=lambda w: get_bcl2fastq_input(w.sequencing_name, w.experiment_name),
+        path=lambda w: get_path(w.sequencing_name, w.experiment_name),
         fake_sample_sheet="{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/fake.csv",
     output:
         R1=temp("{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/Undetermined_S0_R1_001.fastq.gz"),
@@ -59,26 +45,47 @@ rule bcl2fastq:
     params:
         path_out="{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/",
         extra=config["settings"]["bcl2fastq"],
-        path_fastq=lambda w: get_folder_undetermined(w.sequencing_name, w.experiment_name),
     conda:
         "envs/sci-rocket.yaml",
     message: "Converting bcl to fastq with p5 and p7 indexes within the read name ({wildcards.experiment_name}: {wildcards.sequencing_name})."
     shell:
-        """
-        if [ ! -z {params.path_fastq} ]; then
-            # If the path_fastq is defined in the samplesheet, then just symlink the files.
-            ln -s {params.path_fastq}/Undetermined_S0_R1_001.fastq.gz {output.R1}
-            ln -s {params.path_fastq}/Undetermined_S0_R2_001.fastq.gz {output.R2}
-        else
-            # If the path_fastq is not defined in the samplesheet, then run bcl2fastq.
+        r"""
+        exec > "{log}" 2>&1
+        
+        if [[ -f "{input.path}/RunInfo.xml" ]]; then
+            echo "Found RunInfo.xml in {input.path}: running bcl2fastq to convert to fastq.gz"
             bcl2fastq \
             {params.extra} \
-            -R {input.path_bcl} \
-            --sample-sheet {input.fake_sample_sheet} \
-            --output-dir {params.path_out} \
+            -R "{input.path}" \
+            --sample-sheet "{input.fake_sample_sheet}" \
+            --output-dir "{params.path_out}" \
             --loading-threads 8 \
             --processing-threads 30 \
-            --writing-threads 2 &> {log}
+            --writing-threads 2
+        else
+            echo "No RunInfo.xml found in {input.path}, treating input as FASTQ folder"
+            # Look for fastq files of the form *_R1*fastq.gz and *_R2*fastq.gz
+            mapfile -t R1_FILES < <(find "{input.path}" -maxdepth 1 -type f -iname "*R1*.fastq.gz")
+            mapfile -t R2_FILES < <(find "{input.path}" -maxdepth 1 -type f -iname "*R2*.fastq.gz")
+    
+            if [[ ${{#R1_FILES[@]}} -ne 1 || ${{#R2_FILES[@]}} -ne 1 ]]; then
+                echo "ERROR: Expected exactly one R1 and one R2 .fastq.gz in {input.path}"
+                echo "Found ${{#R1_FILES[@]}} R1 files:"
+                printf '  %s\n' "${{R1_FILES[@]}}"
+                echo "Found ${{#R2_FILES[@]}} R2 files:"
+                printf '  %s\n' "${{R2_FILES[@]}}"
+                exit 1
+            fi
+            
+            R1="$(realpath "${{R1_FILES[0]}}")"
+            R2="$(realpath "${{R2_FILES[0]}}")"
+
+            echo "Found fastq.gz files, creating symlinks:"
+            echo "  R1: $R1 -> {output.R1}"
+            echo "  R2: $R2 -> {output.R2}"
+
+            ln -sf "$R1" "{output.R1}"
+            ln -sf "$R2" "{output.R2}"
         fi
         """
 

--- a/workflow/rules/step5_haplotyping.smk
+++ b/workflow/rules/step5_haplotyping.smk
@@ -342,7 +342,7 @@ rule join_counts:
     message:
         "Retrieving counts from {input.counts_h1}, {input.counts_h2} and {input.counts_ua}."
     shell:
-        """
+        r"""
         python3 {workflow.basedir}/rules/scripts/haplotyping/join_counts.py \
             --h1 {input.counts_h1} \
             --h2 {input.counts_h2} \


### PR DESCRIPTION
- automatically determine if a folder contains fastq or bcl data based on the filenames
  - for fastq accept any file with R1 in it for read1, and any file with R2 in it for read2
  - if there are no such valid files, or multiple possible valid files, an error is raised
- remains backwards compatible with old sample sheets that only contain `path_fastq` and/or `path_bcl`
  - they are converted to `path_reads`, with fastq taking precedence if both are provided
- fix a bug with duplicate sequencing_name
  - previously if two rows had different paths, but the same experiment & last folder in the path, they would both get the same sequencing_name
  - this meant the two separate runs would be extracted to the same folder, potentially overwriting each other
  - now they get _1, _2 etc appended to ensure experiment/sequencing_name cannot be the same for entries with differing paths
- add unit test setup with test for the above
- modify some existing tests to use path_reads in their config.yaml
- use updated test data with various different (but valid) names for the fastq files
