### PR TITLE
Add support for AVITI reads

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -18,7 +18,7 @@ rm -rf test_*/output
 # download test data (reads and genome) if not already present
 if [ ! -d "data" ]; then
     mkdir -p data
-    wget -O - https://github.com/lauren-saunders-lab/sci-rocket-test-data/releases/download/2026.01.08/test-data.tgz | tar -xvzf - -C data
+    wget -O - https://github.com/lauren-saunders-lab/sci-rocket-test-data/releases/latest/download/test-data.tgz | tar -xvzf - -C data
 fi
 
 # run each test workflow and its associated pytest tests

--- a/workflow/examples/example_config.yaml
+++ b/workflow/examples/example_config.yaml
@@ -50,6 +50,8 @@ settings:
   star_index: "--sjdbOverhang 83"
   # Custom settings for STARSolo alignment.
   star: "--soloMultiMappers EM --outSAMmultNmax 1 --outSAMstrandField intronMotif --outFilterScoreMinOverLread 0.33 --outFilterMatchNminOverLread 0.33 --outSAMunmapped Within --outSAMattributes NH HI AS nM NM MD jM jI MC ch XS CR UR GX GN sM"
+  # Path to bases2fastq executable (if not provided sci-rocket will download it).
+  bases2fastq_exe: ""
 
 
 ###################################

--- a/workflow/rules/envs/sci-rocket.yaml
+++ b/workflow/rules/envs/sci-rocket.yaml
@@ -8,6 +8,7 @@ dependencies:
   - bioconda::fastp>=0.23.4
   - bioconda::star>=2.7.10b
   - bioconda::sambamba>=1.0
+  - bioconda::fastq-fix-i5
 
   # Python and required modules.
   - conda-forge::python==3.13

--- a/workflow/rules/step1_reads2fastq.smk
+++ b/workflow/rules/step1_reads2fastq.smk
@@ -14,27 +14,62 @@ def get_path(sequencing_name, experiment_name):
     return samples_unique.query("sequencing_name == @sequencing_name & experiment_name == @experiment_name").path_reads.values[0]
 
 
-rule make_fake_samplesheet:
+rule make_fake_bcl_sample_sheet:
     output:
-        sample_sheet=temp("{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/fake.csv"),
-    params:
-        path_out="{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/",
-    message: "Generate fake sample-sheet to allow indexes to be added to R1/R2."
+        sample_sheet=temp("{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/fake_bcl_sample_sheet.csv"),
+    message: "Generate fake BCL sample-sheet to allow indexes to be added to R1/R2."
     shell:
         """
-        # Generate fake sample-sheet to allow indexes to be added to R1/R2.
-        mkdir -p {params.path_out}
+        # Generate fake bcl sample-sheet to allow indexes to be added to R1/R2.
+        mkdir -p $(dirname {output.sample_sheet})
         echo -e "[DATA]\nLane,Sample_ID,Sample_Name,index,index2\n,fake,fake,NNNNNNNNNN,NNNNNNNNNN" > {output.sample_sheet}
+        """
+
+
+rule make_fake_aviti_run_manifest:
+    output:
+        run_manifest=temp("{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/fake_aviti_run_manifest.csv"),
+    message: "Generate fake AVITI run manifest to allow indexes to be added to R1/R2."
+    shell:
+        """
+        # Generate fake AVITI run manifest to allow indexes to be added to R1/R2.
+        mkdir -p $(dirname {output.run_manifest})
+        echo -e "[Samples]\nSampleName,Index1,Index2,Lane\nfake,AAAAAAAAAA,AAAAAAAAAA,1+2\n" > {output.run_manifest}
+        """
+
+
+rule install_bases2fastq:
+    output:
+        bases2fastq_exe="{dir_output}/resources/bases2fastq/bases2fastq",
+    params:
+        bases2fastq_exe = config["settings"].get("bases2fastq_exe", ""),
+    shell:
+        r"""
+        mkdir -p $(dirname {output.bases2fastq_exe})
+        if [ -n "{params.bases2fastq_exe}" ] && [ -x "{params.bases2fastq_exe}" ]; then
+            echo "Using user-provided Bases2Fastq executable: {params.bases2fastq_exe}"
+            ln -sf "{params.bases2fastq_exe}" {output.bases2fastq_exe}
+        else
+            echo "Downloading latest release of Bases2Fastq executable"
+            tmpdir=$(mktemp -d)
+            curl -L https://bases2fastq-release.s3.amazonaws.com/bases2fastq-latest.tar.gz -o "$tmpdir/bases2fastq.tar.gz"
+            tar -xvf "$tmpdir/bases2fastq.tar.gz" -C "$tmpdir"
+            install -m 0755 "$tmpdir/bases2fastq" {output.bases2fastq_exe}
+            rm -rf "$tmpdir"
+        fi
         """
 
 
 rule reads2fastq:
     input:
         path=lambda w: get_path(w.sequencing_name, w.experiment_name),
-        fake_sample_sheet="{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/fake.csv",
+        bcl_sample_sheet=rules.make_fake_bcl_sample_sheet.output.sample_sheet,
+        aviti_run_manifest=rules.make_fake_aviti_run_manifest.output.run_manifest,
+        bases2fastq_exe=rules.install_bases2fastq.output.bases2fastq_exe,
     output:
         R1=temp("{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/Undetermined_S0_R1_001.fastq.gz"),
         R2=temp("{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/Undetermined_S0_R2_001.fastq.gz"),
+        tmp=temp(directory("{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/tmp")),
     log:
         "{dir_output}/logs/step1_bcl2fastq/bcl2fastq_{experiment_name}_{sequencing_name}.log",
     threads: 40
@@ -47,23 +82,40 @@ rule reads2fastq:
         extra=config["settings"]["bcl2fastq"],
     conda:
         "envs/sci-rocket.yaml",
-    message: "Converting bcl to fastq with p5 and p7 indexes within the read name ({wildcards.experiment_name}: {wildcards.sequencing_name})."
+    message: "Converting reads to fastq with p5 and p7 indexes within the read name ({wildcards.experiment_name}: {wildcards.sequencing_name})."
     shell:
         r"""
         exec > "{log}" 2>&1
+        mkdir -p {output.tmp}
         
         if [[ -f "{input.path}/RunInfo.xml" ]]; then
-            echo "Found RunInfo.xml in {input.path}: running bcl2fastq to convert to fastq.gz"
+            echo "Found RunInfo.xml in {input.path}: treating input as BCL run folder."
+            echo "Running bcl2fastq to convert to fastq.gz"
             bcl2fastq \
             {params.extra} \
             -R "{input.path}" \
-            --sample-sheet "{input.fake_sample_sheet}" \
+            --sample-sheet "{input.bcl_sample_sheet}" \
             --output-dir "{params.path_out}" \
             --loading-threads 8 \
             --processing-threads 30 \
             --writing-threads 2
+        elif [[ -d "{input.path}/BaseCalls" ]]; then
+            echo "Found BaseCalls/ in {input.path} (and no RunInfo.xml): treating input as AVITI run folder"
+            echo "Running Bases2Fastq to convert to fastq.gz, then using fastq-fix-i5 to reverse-complement i5 in R1 headers"
+            {input.bases2fastq_exe} \
+            --run-manifest {input.aviti_run_manifest} \
+            --num-threads 8 \
+            --skip-multi-qc \
+            --skip-qc-report \
+            {input.path} \
+            {output.tmp}
+            # Reverse-complement i5 index in R1 fastq headers
+            pigz -dc "{output.tmp}/Samples/DefaultProject/fake/fake_R1.fastq.gz" \
+              | fastq-fix-i5 \
+              | pigz -c > "{output.R1}"
+            mv "{output.tmp}/Samples/DefaultProject/fake/fake_R2.fastq.gz" "{output.R2}"
         else
-            echo "No RunInfo.xml found in {input.path}, treating input as FASTQ folder"
+            echo "No RunInfo.xml or BaseCalls folder found in {input.path}, treating input as FASTQ folder"
             # Look for fastq files of the form *_R1*fastq.gz and *_R2*fastq.gz
             mapfile -t R1_FILES < <(find "{input.path}" -maxdepth 1 -type f -iname "*R1*.fastq.gz")
             mapfile -t R2_FILES < <(find "{input.path}" -maxdepth 1 -type f -iname "*R2*.fastq.gz")


### PR DESCRIPTION
- add python script with tests that reverse complements i5 in .fasta.gz files
- add a snakemake rule to download and install bases2fastq
  - user can also provide the path to the bases2fastq executable in the config to avoid downloading it every time
- add AVITI detection & conversion to fastq with rc i5
  - add fastq-fix-i5 to sci-rocket env and use to rc i5 in the headers
  - this makes the resulting fastq files consistent with those created by bcl2fastq2
  - note: currently no tests for this functionality as we don't have sample aviti data yet