### PR TITLE
Support multiple paths in `path_reads`

### DIFF
--- a/tests/test_bcl_two_runs/samplesheet.tsv
+++ b/tests/test_bcl_two_runs/samplesheet.tsv
@@ -1,3 +1,2 @@
 path_reads	experiment_name	p5	p7	rt	sample_name	species	n_expected_cells	hashing
-../data/reads/bcl/two_runs/run1	zfish	A03:H03	C01:C12	"P01-A01:P01-A07,P01-B01:P01-B07,P01-C01:P01-C07,P01-D01:P01-D07,P01-E01:P01-E07,P01-F01:P01-F07,P01-G01:P01-G07,P01-H01:P01-H07"	zfish-hash	Zebrafish	34000	../hash.tsv
-../data/reads/bcl/two_runs/run2/	zfish	A03:H03	C01:C12	"P01-A01:P01-A07,P01-B01:P01-B07,P01-C01:P01-C07,P01-D01:P01-D07,P01-E01:P01-E07,P01-F01:P01-F07,P01-G01:P01-G07,P01-H01:P01-H07"	zfish-hash	Zebrafish	34000	../hash.tsv
+../data/reads/bcl/two_runs/run1;../data/reads/bcl/two_runs/run2/;;	zfish	A03:H03	C01:C12	"P01-A01:P01-A07,P01-B01:P01-B07,P01-C01:P01-C07,P01-D01:P01-D07,P01-E01:P01-E07,P01-F01:P01-F07,P01-G01:P01-G07,P01-H01:P01-H07"	zfish-hash	Zebrafish	34000	../hash.tsv

--- a/tests/unit/demultiplexing/test_preprocess.py
+++ b/tests/unit/demultiplexing/test_preprocess.py
@@ -1,6 +1,7 @@
 import pytest
 import pathlib
 import workflow.rules.scripts.demultiplexing.preprocess as preprocess
+import pandas as pd
 
 
 def write_tsv(path, header, rows):
@@ -43,9 +44,53 @@ def test_get_samples_deduplicated_sequencing_names(test_config: dict):
               ], )
     samples = preprocess.get_samples(test_config)
     assert samples["sequencing_name"][0] == "r1"  # exp/r1: first r1 in exp, so ok as is
-    assert samples["sequencing_name"][1] == "r1_1"  # exp/r1_1: second r1 in exp & has different path (/other/r1) to first one, so renamed
+    assert samples["sequencing_name"][
+               1] == "r1_1"  # exp/r1_1: second r1 in exp & has different path (/other/r1) to first one, so renamed
     assert samples["sequencing_name"][2] == "r1"  # exp/r1: repeat of first r1 path in exp, so ok as is
     assert samples["sequencing_name"][3] == "r1"  # exp2/r1: different experiment, so ok as is
     assert samples["sequencing_name"][4] == "r2"  # exp/r2: first r2 in exp, so ok as is
     assert samples["sequencing_name"][5] == "r1_1"  # exp2/r1_1: second r1 in exp2 with different path, so renamed
     assert samples["sequencing_name"][6] == "r1_1"  # exp1/r1_1: same path & exp as sample 2
+
+
+def test_get_samples_path_reads_with_multiple_paths(test_config: dict):
+    write_tsv(
+        test_config["path_samples"],
+        header=["path_reads", "experiment_name", "p5", "p7", "rt", "sample_name", "species", "n_expected_cells"],
+        rows=[
+            # single path, no semicolon -> single row
+            ["path/r1", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s1", "mouse", "10000"],
+            # single path, trailing semicolon -> single row
+            ["/path/r2;", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s2", "mouse", "10000"],
+            # two paths separated by a semicolon with trailing slashes -> two rows without trailing slashes
+            ["/path/a/;/path/b/", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s3", "mouse", "10000"],
+            # four paths separated by semicolons -> four rows
+            ["/path/a1;/path/a2;/path/a3;/path/a4", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s3", "mouse",
+             "10000"],
+            # duplicate paths in same cell -> single row with single path
+            ["c://dup;c://dup", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s4", "mouse", "10000"],
+            # whitespace around tokens -> single rows with trimmed paths
+            [" /ws1 ;  /ws2  ", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s5", "mouse", "10000"],
+            # empty tokens from double semicolons + trailing -> two rows with trimmed paths
+            [";/x;;/y;", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s6", "mouse", "10000"],
+        ],
+    )
+
+    expected_samples = pd.DataFrame([
+        ["path/r1", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s1", "mouse", "10000", "r1"],
+        ["/path/r2", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s2", "mouse", "10000", "r2"],
+        ["/path/a", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s3", "mouse", "10000", "a"],
+        ["/path/b", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s3", "mouse", "10000", "b"],
+        ["/path/a1", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s3", "mouse", "10000", "a1"],
+        ["/path/a2", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s3", "mouse", "10000", "a2"],
+        ["/path/a3", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s3", "mouse", "10000", "a3"],
+        ["/path/a4", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s3", "mouse", "10000", "a4"],
+        ["c://dup", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s4", "mouse", "10000", "dup"],
+        ["/ws1", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s5", "mouse", "10000", "ws1"],
+        ["/ws2", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s5", "mouse", "10000", "ws2"],
+        ["/x", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s6", "mouse", "10000", "x"],
+        ["/y", "exp", "A02:H02", "H01:H12", "P01-A01:P01-D12", "s6", "mouse", "10000", "y"],
+    ], columns=["path_reads", "experiment_name", "p5", "p7", "rt", "sample_name", "species", "n_expected_cells", "sequencing_name"])
+
+    samples = preprocess.get_samples(test_config)
+    pd.testing.assert_frame_equal(samples.reset_index(drop=True), expected_samples)

--- a/workflow/rules/scripts/demultiplexing/preprocess.py
+++ b/workflow/rules/scripts/demultiplexing/preprocess.py
@@ -301,18 +301,25 @@ def get_samples(config: dict) -> pd.DataFrame:
     # Perform sanity checks.
     check_sanity(samples, barcodes, config)
 
-    if "path_fastq" in samples.columns and "path_bcl" in samples.columns:
-        print("Both BCL and FASTQ paths are specified in the samples file. Will start from FASTQ.")
-
     # If 'path_reads' column is not provided, use 'path_bcl' or 'path_fastq' column as 'path_reads'.
     if "path_reads" not in samples.columns:
+        if "path_fastq" in samples.columns and "path_bcl" in samples.columns:
+            print("Both BCL and FASTQ paths are specified in the samples file - using FASTQ.")
         for col in ["path_bcl", "path_fastq"]:
             if col in samples.columns:
                 samples["path_reads"] = samples[col]
                 samples.drop(col, axis=1, inplace=True)
-    samples["path_reads"] = samples["path_reads"].str.rstrip("/")
 
-    # Drop duplicate rows based on experiment_name, sample_name, species and path.
+    # Split any path_reads entries which contain multiple semicolon-separated paths into multiple rows.
+    samples = (
+        samples
+        .assign(path_reads=samples["path_reads"].str.split(";"))
+        .explode("path_reads", ignore_index=True)
+        .assign(path_reads=lambda d: d["path_reads"].str.strip().str.rstrip("/"))
+        .query("path_reads != ''")
+    )
+
+    # Drop duplicate rows based on experiment_name, sample_name, species and path_reads.
     samples.drop_duplicates(subset=["path_reads", "experiment_name", "sample_name", "species"], inplace=True)
 
     # Generate the sequencing_name based on the last folder name of the path


### PR DESCRIPTION
- support multiple paths (separated by a semicolon) in `path_reads`
- add unit tests for this
- update a workflow test to use this feature