### PR TITLE
Make sorting of hash counts deterministic

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -24,7 +24,7 @@ fi
 # run each test workflow and its associated pytest tests
 for test_dir in test_bcl_one_run test_bcl_two_runs test_fastq_from_bcl_one_run test_fastq_from_bcl_two_runs test_fastq_from_aviti_one_run test_fastq_from_aviti_two_runs; do
     snakemake --cores all --use-conda --configfile $test_dir/config.yaml -s ../workflow/Snakefile -d $test_dir
-    pytest $test_dir
+    pytest $test_dir -vvv
 done
 
 echo "All tests completed successfully."

--- a/tests/test_bcl_one_run/tests/test_hashing.py
+++ b/tests/test_bcl_one_run/tests/test_hashing.py
@@ -18,6 +18,6 @@ def test_hashing_metrics():
     data = read_tsv(hashing_metrics)
     assert len(data) == 1675
     # check top three
-    assert data[0] == ['zfish', 'zfish-hash', '20uM_P7_G10', 'AATATTACTTGAACTGCATCCCAAGGATTGTCCAATCATC', '10', '3']
-    assert data[1] == ['zfish', 'zfish-hash', '40uM_P7_F12', 'CGCGGCCATACGGCGAGACCTACTTGCGTGGCGTTGGAGC', '10', '6']
+    assert data[0] == ['zfish', 'zfish-hash', '40uM_P7_F12', 'CGCGGCCATACGGCGAGACCTACTTGCGTGGCGTTGGAGC', '10', '6']
+    assert data[1] == ['zfish', 'zfish-hash', '20uM_P7_G10', 'AATATTACTTGAACTGCATCCCAAGGATTGTCCAATCATC', '10', '3']
     assert data[2] == ['zfish', 'zfish-hash', '40uM_P7_B12', 'ATTGGCAGATGTTGACGGCCGCTCTTAGTGTCCGGCCTCG', '8', '5']

--- a/tests/test_fastq_from_aviti_one_run/tests/test_hashing.py
+++ b/tests/test_fastq_from_aviti_one_run/tests/test_hashing.py
@@ -20,6 +20,6 @@ def test_hashing_metrics():
     # check top five
     assert data[0] == ['Drer.ZAe', 'ZAe-14hpf-28', '10uM_P7_D7', 'TTGATTGGCGGGCCGTCAACAATTCTAGGTTTAATTGAAT', '22', '22']
     assert data[1] == ['Drer.ZAe', 'ZAe-14hpf-28', '10uM_P7_A8', 'CTAGCCAGCCCTTAATCTTGCGTCTTCCTGTATCATGATC', '17', '17']
-    assert data[2] == ['Drer.ZAe', 'ZAe-14hpf-28', '10uM_P7_B7', 'GCATATGAGCCTCCTGGACCTGATGCGATGGTTACGCAAG', '15', '15']
-    assert data[3] == ['Drer.ZAe', 'ZAe-14hpf-28', '10uM_P7_A7', 'TTGGCAAGCCGGTCTCGCCGATGGTTGGTGACTATAGGTT', '15', '15']
+    assert data[2] == ['Drer.ZAe', 'ZAe-14hpf-28', '10uM_P7_A7', 'TTGGCAAGCCGGTCTCGCCGATGGTTGGTGACTATAGGTT', '15', '15']
+    assert data[3] == ['Drer.ZAe', 'ZAe-14hpf-28', '10uM_P7_B7', 'GCATATGAGCCTCCTGGACCTGATGCGATGGTTACGCAAG', '15', '15']
     assert data[4] == ['Drer.ZAe', 'ZAe-14hpf-28', '10uM_P7_C7', 'TGCGACCTCTGGTCTCGCCGTGGATTCTATGAGCATATGG', '14', '14']

--- a/workflow/rules/scripts/demultiplexing/demux_dash.py
+++ b/workflow/rules/scripts/demultiplexing/demux_dash.py
@@ -40,8 +40,8 @@ def write_cell_hashing_table(qc, out):
     # Convert to pandas dataframe.
     df_hashing = pd.DataFrame(columns=["experiment_name", "sample_name", "hashing_name", "cell_barcode", "count", "n_umi"], data=array_hashing)
 
-    # Order on total hash count.
-    df_hashing = df_hashing.sort_values(by=["count"], ascending=False)
+    # Order on total hash count (and by cell_barcode for equal counts).
+    df_hashing = df_hashing.sort_values(by=["count", "cell_barcode"], ascending=False)
 
     # Generate folder.
     if not os.path.exists(os.path.dirname(out)):


### PR DESCRIPTION
- sort by count and n_umi, instead of just by count
- resolves intermittent failing test where order of two rows with the same hash count sometimes changed