### PR TITLE
Fix bug in reduction of uncorrectable barcodes data

### DIFF
--- a/tests/unit/demultiplexing/test_preprocess.py
+++ b/tests/unit/demultiplexing/test_preprocess.py
@@ -93,4 +93,4 @@ def test_get_samples_path_reads_with_multiple_paths(test_config: dict):
     ], columns=["path_reads", "experiment_name", "p5", "p7", "rt", "sample_name", "species", "n_expected_cells", "sequencing_name"])
 
     samples = preprocess.get_samples(test_config)
-    pd.testing.assert_frame_equal(samples.reset_index(drop=True), expected_samples)
+    pd.testing.assert_frame_equal(samples.reset_index(drop=True), expected_samples, check_dtype=False)

--- a/workflow/rules/scripts/demultiplexing/demux_rocket.py
+++ b/workflow/rules/scripts/demultiplexing/demux_rocket.py
@@ -266,7 +266,7 @@ def update_qc(qc:dict, x:sciRecord):
     # This reduces the size of the pickle file and we only display the top 15 in the QC report.
     if qc["n_pairs"] % 1000000 == 0:
         for key in ["p5", "p7", "ligation", "rt"]:
-            qc[f"uncorrectable_{key}"] = sorted(qc[f"uncorrectable_{key}"], key=lambda item: item[1], reverse=True)[:50]
+            qc[f"uncorrectable_{key}"] = defaultdict(int, dict(sorted(qc[f"uncorrectable_{key}"].items(), key=lambda kv: kv[1], reverse=True)[:50]))
 
     # Return the updated QC dictionary.
     return qc


### PR DESCRIPTION
- was accidentally converting the dict to a list
- this was not picked up by the tests as it only happens after 1M reads