### PR TITLE
Add benchmarks / job run info to dashboard

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -29,6 +29,9 @@ wildcard_constraints:
 # Workflow output. ----
 
 dir_output = config["dir_output"].rstrip("/")
+def out(p: str) -> str:
+    return f"{dir_output}/{p.lstrip('/')}"
+
 
 # Scatter-gather settings.
 scattergather:
@@ -38,11 +41,11 @@ scattergather:
 rule all:
     input:
         # Run sci-rocket demultiplexing pipeline.
-        expand(f"{dir_output}/{{experiment_name}}/sci-dash/", experiment_name=samples_unique["experiment_name"]),
+        expand(out("{experiment_name}/sci-dash/"), experiment_name=samples_unique["experiment_name"]),
        
         # Optional haplotyping rule (Mus musculus).
         expand(
-            f"{dir_output}/{{experiment_name}}/haplotyping/{{sample_name}}_{{strain1}}_{{strain2}}_haplotagged_readcounts.txt",
+            out("{experiment_name}/haplotyping/{sample_name}_{strain1}_{strain2}_haplotagged_readcounts.txt"),
             experiment_name=samples_unique_haplotyping["experiment_name"],
             sample_name=samples_unique_haplotyping["sample_name"],
             strain1=samples_unique_haplotyping["strain1"],

--- a/workflow/rules/scripts/demultiplexing/demux_dash.py
+++ b/workflow/rules/scripts/demultiplexing/demux_dash.py
@@ -5,6 +5,20 @@ import os
 import pandas as pd
 import pickle
 import sys
+import pathlib
+
+
+def get_benchmarks(path_benchmarks) -> list[dict]:
+    frames = []
+    for path in sorted(pathlib.Path(path_benchmarks).glob("*.txt")) + sorted(pathlib.Path(path_benchmarks).parent.glob("*.txt")):
+        df = pd.read_csv(path, sep="\t")
+        df.insert(0, "job", path.stem)
+        frames.append(df)
+    if not frames:
+        return []
+    df = pd.concat(frames, ignore_index=True, sort=False)
+    return df.to_dict('records')
+
 
 def write_cell_hashing_table(qc, out):
     """
@@ -63,7 +77,7 @@ def write_cell_hashing_table(qc, out):
     return dict_hashing
 
 
-def combine_logs(path_pickle, path_star, path_hashing):
+def combine_logs(path_pickle, path_star, path_hashing, path_benchmarks):
     """
     Combine the demuxxing logs with the STAR logs for the sci-dash.
 
@@ -71,6 +85,7 @@ def combine_logs(path_pickle, path_star, path_hashing):
         path_pickle (str): Path to the pickled dictionaries.
         path_star (str): Path to the STAR output folder.
         path_hashing (str): Path to store the hashing metrics.
+        path_benchmarks (str): Path to workflow benchmarks.
 
     Returns:
         qc (dict): Dictionary containing the demuxxing statistics (in JSON format).
@@ -191,6 +206,8 @@ def combine_logs(path_pickle, path_star, path_hashing):
         qc_json["hashing"] = {}
     # endregion ----------------------------------------------------------------------------------------------------------
 
+    qc_json["benchmarks"] = get_benchmarks(path_benchmarks)
+
     # Return JSON-structured dict.
     return qc_json
 
@@ -202,6 +219,7 @@ def main(arguments):
     parser.add_argument("--path_star", required=True, type=str, help="(str) Path to the star alignment folder.")
     parser.add_argument("--path_out", required=True, type=str, help="(str) Path to store JSON structure.")
     parser.add_argument("--path_hashing", required=True, type=str, help="(str) Path to store hashing metrics (if applicable).")
+    parser.add_argument("--path_benchmarks", required=True, type=str, help="(str) Path to workflow benchmarks.")
 
     parser.add_argument("-h", "--help", action="help", default=argparse.SUPPRESS, help="Display help and exit.")
 
@@ -209,7 +227,7 @@ def main(arguments):
     args = parser.parse_args()
 
     # Combine the demuxxing logs with the STAR logs for the sci-dash.
-    qc_json = combine_logs(args.path_pickle, args.path_star, args.path_hashing)
+    qc_json = combine_logs(args.path_pickle, args.path_star, args.path_hashing, args.path_benchmarks)
 
     # Write the JSON structure to file.
     if not os.path.exists(os.path.dirname(args.path_out)):

--- a/workflow/rules/scripts/demultiplexing/demux_rocket.py
+++ b/workflow/rules/scripts/demultiplexing/demux_rocket.py
@@ -525,6 +525,7 @@ def sciseq_sample_demultiplexing(log: logging.Logger, experiment_name: str, samp
         log.info("Done: %d read-pairs processed (%d discarded, %d hashing reads)", qc["n_pairs"], qc["n_pairs_failure"], qc["n_hashing"])
     else:
         log.info("Done: %d read-pairs processed (%d discarded,)", qc["n_pairs"], qc["n_pairs_failure"])
+    log.info(sciRecord._sciRecord__find_closest_match.cache_info())
         
     # Close the file handlers.
     for fh in dict_fh.values():

--- a/workflow/rules/step1_reads2fastq.smk
+++ b/workflow/rules/step1_reads2fastq.smk
@@ -14,41 +14,24 @@ def get_path(sequencing_name, experiment_name):
     return samples_unique.query("sequencing_name == @sequencing_name & experiment_name == @experiment_name").path_reads.values[0]
 
 
-rule make_fake_bcl_sample_sheet:
-    output:
-        sample_sheet=temp("{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/fake_bcl_sample_sheet.csv"),
-    message: "Generate fake BCL sample-sheet to allow indexes to be added to R1/R2."
-    shell:
-        """
-        # Generate fake bcl sample-sheet to allow indexes to be added to R1/R2.
-        mkdir -p $(dirname {output.sample_sheet})
-        echo -e "[DATA]\nLane,Sample_ID,Sample_Name,index,index2\n,fake,fake,NNNNNNNNNN,NNNNNNNNNN" > {output.sample_sheet}
-        """
-
-
-rule make_fake_aviti_run_manifest:
-    output:
-        run_manifest=temp("{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/fake_aviti_run_manifest.csv"),
-    message: "Generate fake AVITI run manifest to allow indexes to be added to R1/R2."
-    shell:
-        """
-        # Generate fake AVITI run manifest to allow indexes to be added to R1/R2.
-        mkdir -p $(dirname {output.run_manifest})
-        echo -e "[Samples]\nSampleName,Index1,Index2,Lane\nfake,AAAAAAAAAA,AAAAAAAAAA,1+2\n" > {output.run_manifest}
-        """
-
-
 rule install_bases2fastq:
     output:
-        bases2fastq_exe="{dir_output}/resources/bases2fastq/bases2fastq",
+        bases2fastq_exe=out("resources/bases2fastq/bases2fastq"),
     params:
         bases2fastq_exe = config["settings"].get("bases2fastq_exe", ""),
+    log:
+        out("logs/step1_reads2fastq/install_bases2fastq.log"),
     shell:
         r"""
+        exec > "{log}" 2>&1
         mkdir -p $(dirname {output.bases2fastq_exe})
         if [ -n "{params.bases2fastq_exe}" ] && [ -x "{params.bases2fastq_exe}" ]; then
             echo "Using user-provided Bases2Fastq executable: {params.bases2fastq_exe}"
             ln -sf "{params.bases2fastq_exe}" {output.bases2fastq_exe}
+        elif command -v bases2fastq >/dev/null 2>&1; then
+            found_exe=$(command -v bases2fastq)
+            echo "Using Bases2Fastq found on PATH: $found_exe"
+            ln -sf "$found_exe" {output.bases2fastq_exe}
         else
             echo "Downloading latest release of Bases2Fastq executable"
             tmpdir=$(mktemp -d)
@@ -63,22 +46,20 @@ rule install_bases2fastq:
 rule reads2fastq:
     input:
         path=lambda w: get_path(w.sequencing_name, w.experiment_name),
-        bcl_sample_sheet=rules.make_fake_bcl_sample_sheet.output.sample_sheet,
-        aviti_run_manifest=rules.make_fake_aviti_run_manifest.output.run_manifest,
         bases2fastq_exe=rules.install_bases2fastq.output.bases2fastq_exe,
     output:
-        R1=temp("{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/Undetermined_S0_R1_001.fastq.gz"),
-        R2=temp("{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/Undetermined_S0_R2_001.fastq.gz"),
-        tmp=temp(directory("{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/tmp")),
+        R1=temp(out("{experiment_name}/raw_reads/{sequencing_name}/Undetermined_S0_R1_001.fastq.gz")),
+        R2=temp(out("{experiment_name}/raw_reads/{sequencing_name}/Undetermined_S0_R2_001.fastq.gz")),
+        tmp=temp(directory(out("{experiment_name}/raw_reads/{sequencing_name}/tmp"))),
     log:
-        "{dir_output}/logs/step1_bcl2fastq/bcl2fastq_{experiment_name}_{sequencing_name}.log",
+        out("logs/step1_reads2fastq/reads2fastq_{experiment_name}_{sequencing_name}.log"),
     threads: 40
     resources:
-        mem_mb=1024 * 40,
+        mem_mb=1024 * 48,
     benchmark:
-        "{dir_output}/benchmarks/bcl2fastq_{experiment_name}_{sequencing_name}.txt"
+        out("benchmarks/{experiment_name}/reads2fastq_{sequencing_name}.txt")
     params:
-        path_out="{dir_output}/{experiment_name}/raw_reads/{sequencing_name}/",
+        path_out=out("{experiment_name}/raw_reads/{sequencing_name}"),
         extra=config["settings"]["bcl2fastq"],
     conda:
         "envs/sci-rocket.yaml",
@@ -91,10 +72,12 @@ rule reads2fastq:
         if [[ -f "{input.path}/RunInfo.xml" ]]; then
             echo "Found RunInfo.xml in {input.path}: treating input as BCL run folder."
             echo "Running bcl2fastq to convert to fastq.gz"
+            echo -e "[DATA]\nLane,Sample_ID,Sample_Name,index,index2\n,fake,fake,NNNNNNNNNN,NNNNNNNNNN" > "{params.path_out}/fake_bcl_sample_sheet.csv"
+            # 40 cores / 40GB RAM: 2GB/core needed according to Illumina bcl2fastq docs
             bcl2fastq \
             {params.extra} \
             -R "{input.path}" \
-            --sample-sheet "{input.bcl_sample_sheet}" \
+            --sample-sheet "{params.path_out}/fake_bcl_sample_sheet.csv" \
             --output-dir "{params.path_out}" \
             --loading-threads 8 \
             --processing-threads 30 \
@@ -102,8 +85,10 @@ rule reads2fastq:
         elif [[ -d "{input.path}/BaseCalls" ]]; then
             echo "Found BaseCalls/ in {input.path} (and no RunInfo.xml): treating input as AVITI run folder"
             echo "Running Bases2Fastq to convert to fastq.gz, then using fastq-fix-i5 to reverse-complement i5 in R1 headers"
+            echo -e "[Samples]\nSampleName,Index1,Index2,Lane\nfake,AAAAAAAAAA,AAAAAAAAAA,1+2\n" > "{params.path_out}/fake_aviti_run_manifest.csv"
+            # 8 cores / 48GB RAM: 6GB/core needed according to https://docs.elembio.io/docs/bases2fastq/setup/#memory-and-performance
             {input.bases2fastq_exe} \
-            --run-manifest {input.aviti_run_manifest} \
+            --run-manifest "{params.path_out}/fake_aviti_run_manifest.csv" \
             --num-threads 8 \
             --skip-multi-qc \
             --skip-qc-report \
@@ -147,24 +132,31 @@ def get_sequencing_runs(experiment_name):
 
 rule merge_sequencing_runs:
     input:
-        R1=lambda w: expand(f"{dir_output}/{{experiment_name}}/raw_reads/{{sequencing_name}}/Undetermined_S0_R1_001.fastq.gz", experiment_name=w.experiment_name, sequencing_name=get_sequencing_runs(w.experiment_name)),
-        R2=lambda w: expand(f"{dir_output}/{{experiment_name}}/raw_reads/{{sequencing_name}}/Undetermined_S0_R2_001.fastq.gz", experiment_name=w.experiment_name, sequencing_name=get_sequencing_runs(w.experiment_name)),
+        R1=lambda w: expand(out("{experiment_name}/raw_reads/{sequencing_name}/Undetermined_S0_R1_001.fastq.gz"), experiment_name=w.experiment_name, sequencing_name=get_sequencing_runs(w.experiment_name)),
+        R2=lambda w: expand(out("{experiment_name}/raw_reads/{sequencing_name}/Undetermined_S0_R2_001.fastq.gz"), experiment_name=w.experiment_name, sequencing_name=get_sequencing_runs(w.experiment_name)),
     output:
-        R1="{dir_output}/{experiment_name}/raw_reads/Undetermined_S0_R1_001.fastq.gz",
-        R2="{dir_output}/{experiment_name}/raw_reads/Undetermined_S0_R2_001.fastq.gz",
+        R1=out("{experiment_name}/raw_reads/Undetermined_S0_R1_001.fastq.gz"),
+        R2=out("{experiment_name}/raw_reads/Undetermined_S0_R2_001.fastq.gz"),
+    log:
+        out("logs/step1_reads2fastq/merge_sequencing_runs_{experiment_name}.log"),
     threads: 1
     resources:
         mem_mb=1024 * 2,
     params:
         total_sequencing_runs=lambda w: len(get_sequencing_runs(w.experiment_name)),
     message: "Merge sequencing runs ({wildcards.experiment_name})."
+    benchmark:
+        out("benchmarks/{experiment_name}/merge_sequencing_runs.txt")
     shell:
         """
+        exec > "{log}" 2>&1
         # If only one sequencing run, then just hardlink it (and remove the original).
         if [ {params.total_sequencing_runs} -eq 1 ]; then
+            echo "Only one sequencing run found, creating hardlinks."
             ln {input.R1} {output.R1}
             ln {input.R2} {output.R2}
         else
+            echo "Multiple sequencing runs found, concatenating fastq.gz files."
             cat {input.R1} > {output.R1}
             cat {input.R2} > {output.R2}
         fi

--- a/workflow/rules/step2_demultiplexing_fastq.smk
+++ b/workflow/rules/step2_demultiplexing_fastq.smk
@@ -125,7 +125,7 @@ rule gather_demultiplexed_sequencing:
     resources:
         mem_mb=1024 * 10,
     benchmark:
-        out("benchmarks/gather_demultiplexed_sequencing_{experiment_name}.txt")
+        out("benchmarks/{experiment_name}/gather_demultiplexed_sequencing.txt")
     params:
         path_demux_scatter=lambda w: out(f"{w.experiment_name}/demux_reads_scatter/")
     conda:

--- a/workflow/rules/step2_demultiplexing_fastq.smk
+++ b/workflow/rules/step2_demultiplexing_fastq.smk
@@ -10,21 +10,22 @@
 # ---- Split R1 and R2 files into smaller files which will be handled in parallel. ----
 rule split_R1:
     input:
-        "{dir_output}/{experiment_name}/raw_reads/Undetermined_S0_R1_001.fastq.gz",
+        out("{experiment_name}/raw_reads/Undetermined_S0_R1_001.fastq.gz"),
     output:
         temp(
             scatter.fastq_split(
-                "{{dir_output}}/{{experiment_name}}/raw_reads_split/R1_{scatteritem}.fastq.gz"
+                out("{{experiment_name}}/raw_reads_split/R1_{scatteritem}.fastq.gz")
             )
         ),
     threads: 5
     resources:
         mem_mb=1024 * 10,
     benchmark:
-        "{dir_output}/benchmarks/split_R1_{experiment_name}.txt"
+        out("benchmarks/{experiment_name}/split_R1.txt")
     params:
         out=lambda w: [
-            f"-o {dir_output}/{w.experiment_name}/raw_reads_split/R1_{i}-of-"
+            "-o " +
+            out(f"{w.experiment_name}/raw_reads_split/R1_{i}-of-")
             + str(workflow._scatter["fastq_split"])
             + ".fastq.gz"
             for i in range(1, workflow._scatter["fastq_split"] + 1)
@@ -41,21 +42,22 @@ rule split_R1:
 
 rule split_R2:
     input:
-        "{dir_output}/{experiment_name}/raw_reads/Undetermined_S0_R2_001.fastq.gz",
+        out("{experiment_name}/raw_reads/Undetermined_S0_R2_001.fastq.gz"),
     output:
         temp(
             scatter.fastq_split(
-                "{{dir_output}}/{{experiment_name}}/raw_reads_split/R2_{scatteritem}.fastq.gz"
+                out("{{experiment_name}}/raw_reads_split/R2_{scatteritem}.fastq.gz")
             )
         ),
     threads: 5
     resources:
         mem_mb=1024 * 10,
     benchmark:
-        "{dir_output}/benchmarks/split_R2_{experiment_name}.txt"
+        out("benchmarks/{experiment_name}/split_R2.txt")
     params:
         out=lambda w: [
-            f"-o {dir_output}/{w.experiment_name}/raw_reads_split/R2_{i}-of-"
+            "-o " +
+            out(f"{w.experiment_name}/raw_reads_split/R2_{i}-of-")
             + str(workflow._scatter["fastq_split"])
             + ".fastq.gz"
             for i in range(1, workflow._scatter["fastq_split"] + 1)
@@ -73,20 +75,20 @@ rule split_R2:
        
 rule demultiplex_fastq_split:
     input:
-        R1="{dir_output}/{experiment_name}/raw_reads_split/R1_{scatteritem}.fastq.gz",
-        R2="{dir_output}/{experiment_name}/raw_reads_split/R2_{scatteritem}.fastq.gz",
+        R1=out("{experiment_name}/raw_reads_split/R1_{scatteritem}.fastq.gz"),
+        R2=out("{experiment_name}/raw_reads_split/R2_{scatteritem}.fastq.gz"),
     output:
-        out_dir=temp(directory("{dir_output}/{experiment_name}/demux_reads_scatter/{scatteritem}/")),
-        discard_R1=temp("{dir_output}/{experiment_name}/demux_reads_scatter/{scatteritem}/{experiment_name}_R1_discarded.fastq.gz"),
-        discard_R2=temp("{dir_output}/{experiment_name}/demux_reads_scatter/{scatteritem}/{experiment_name}_R2_discarded.fastq.gz"),
-        discard_log=temp("{dir_output}/{experiment_name}/demux_reads_scatter/{scatteritem}/log_{experiment_name}_discarded_reads.tsv.gz"),
+        out_dir=temp(directory(out("{experiment_name}/demux_reads_scatter/{scatteritem}"))),
+        discard_R1=temp(out("{experiment_name}/demux_reads_scatter/{scatteritem}/{experiment_name}_R1_discarded.fastq.gz")),
+        discard_R2=temp(out("{experiment_name}/demux_reads_scatter/{scatteritem}/{experiment_name}_R2_discarded.fastq.gz")),
+        discard_log=temp(out("{experiment_name}/demux_reads_scatter/{scatteritem}/log_{experiment_name}_discarded_reads.tsv.gz")),
     log:
-        "{dir_output}/logs/step2_demultiplexing_reads/demultiplex_fastq_split_{experiment_name}_{scatteritem}.log",
+        out("logs/step2_demultiplexing_reads/demultiplex_fastq_split_{experiment_name}_{scatteritem}.log"),
     threads: 1
     resources:
         mem_mb=1024 * 5,
     benchmark:
-        "{dir_output}/benchmarks/demultiplex_fastq_split_{experiment_name}_{scatteritem}.txt"
+        out("benchmarks/{experiment_name}/demultiplex_fastq_split_{scatteritem}.txt")
     params:
         path_samples=config["path_samples"],
         path_barcodes=config["path_barcodes"],
@@ -96,7 +98,7 @@ rule demultiplex_fastq_split:
         "Demultiplexing the scattered .fastq.gz files ({wildcards.experiment_name})."
     shell:
         """
-        python3 {workflow.basedir}/rules/scripts/demultiplexing/demux_rocket.py \
+        python {workflow.basedir}/rules/scripts/demultiplexing/demux_rocket.py \
         --experiment_name {wildcards.experiment_name} \
         --samples {params.path_samples} \
         --barcodes {params.path_barcodes} \
@@ -107,23 +109,25 @@ rule demultiplex_fastq_split:
 
 rule gather_demultiplexed_sequencing:
     input:
-        gather.fastq_split("{{dir_output}}/{{experiment_name}}/demux_reads_scatter/{scatteritem}/"),
+        gather.fastq_split(out("{{experiment_name}}/demux_reads_scatter/{scatteritem}/")),
     output:
-        R1_discarded="{dir_output}/{experiment_name}/demux_reads/{experiment_name}_R1_discarded.fastq.gz",
-        R2_discarded="{dir_output}/{experiment_name}/demux_reads/{experiment_name}_R2_discarded.fastq.gz",
-        discarded_log="{dir_output}/{experiment_name}/demux_reads/log_{experiment_name}_discarded_reads.tsv.gz",
-        qc="{dir_output}/{experiment_name}/demux_reads/{experiment_name}_qc.pickle",
-        whitelist_p7="{dir_output}/{experiment_name}/demux_reads/{experiment_name}_whitelist_p7.txt",
-        whitelist_p5="{dir_output}/{experiment_name}/demux_reads/{experiment_name}_whitelist_p5.txt",
-        whitelist_ligation="{dir_output}/{experiment_name}/demux_reads/{experiment_name}_whitelist_ligation.txt",
-        whitelist_rt="{dir_output}/{experiment_name}/demux_reads/{experiment_name}_whitelist_rt.txt",
+        R1_discarded=out("{experiment_name}/demux_reads/{experiment_name}_R1_discarded.fastq.gz"),
+        R2_discarded=out("{experiment_name}/demux_reads/{experiment_name}_R2_discarded.fastq.gz"),
+        discarded_log=out("{experiment_name}/demux_reads/log_{experiment_name}_discarded_reads.tsv.gz"),
+        qc=out("{experiment_name}/demux_reads/{experiment_name}_qc.pickle"),
+        whitelist_p7=out("{experiment_name}/demux_reads/{experiment_name}_whitelist_p7.txt"),
+        whitelist_p5=out("{experiment_name}/demux_reads/{experiment_name}_whitelist_p5.txt"),
+        whitelist_ligation=out("{experiment_name}/demux_reads/{experiment_name}_whitelist_ligation.txt"),
+        whitelist_rt=out("{experiment_name}/demux_reads/{experiment_name}_whitelist_rt.txt"),
+    log:
+        out("logs/step2_demultiplexing_reads/gather_demultiplexed_sequencing_{experiment_name}.log"),
     threads: 1
     resources:
         mem_mb=1024 * 10,
     benchmark:
-        "{dir_output}/benchmarks/gather_demultiplexed_sequencing_{experiment_name}.txt"
+        out("benchmarks/gather_demultiplexed_sequencing_{experiment_name}.txt")
     params:
-        path_demux_scatter=lambda w: f"{dir_output}/{w.experiment_name}/demux_reads_scatter/"
+        path_demux_scatter=lambda w: out(f"{w.experiment_name}/demux_reads_scatter/")
     conda:
         "envs/sci-rocket.yaml",
     message:
@@ -131,7 +135,7 @@ rule gather_demultiplexed_sequencing:
     shell:
         """
         # Combine pickles.
-        python3 {workflow.basedir}/rules/scripts/demultiplexing/demux_gather.py --path_demux_scatter {params.path_demux_scatter} --path_out {output.qc}
+        python {workflow.basedir}/rules/scripts/demultiplexing/demux_gather.py --path_demux_scatter {params.path_demux_scatter} --path_out {output.qc}
 
         # Combine the sequencing-specific R1/R2 discarded reads and logs.
         find {params.path_demux_scatter} -maxdepth 2 -type f -name {wildcards.experiment_name}_R1_discarded.fastq.gz -print0 | xargs -0 cat > {output.R1_discarded}
@@ -147,17 +151,17 @@ rule gather_demultiplexed_sequencing:
 
 rule gather_demultiplexed_samples:
     input:
-        gather.fastq_split("{{dir_output}}/{{experiment_name}}/demux_reads_scatter/{scatteritem}/"),
+        gather.fastq_split(out("{{experiment_name}}/demux_reads_scatter/{scatteritem}/")),
     output:
-        R1="{dir_output}/{experiment_name}/demux_reads/{sample_name}_R1.fastq.gz",
-        R2="{dir_output}/{experiment_name}/demux_reads/{sample_name}_R2.fastq.gz",
+        R1=out("{experiment_name}/demux_reads/{sample_name}_R1.fastq.gz"),
+        R2=out("{experiment_name}/demux_reads/{sample_name}_R2.fastq.gz"),
     threads: 1
     resources:
         mem_mb=1024 * 10,
     benchmark:
-        "{dir_output}/benchmarks/gather_demultiplexed_samples_{experiment_name}_{sample_name}.txt"
+        out("benchmarks/{experiment_name}/gather_demultiplexed_samples_{sample_name}.txt")
     params:
-        path_demux_scatter=lambda w: f"{dir_output}/{w.experiment_name}/demux_reads_scatter/"
+        path_demux_scatter=lambda w: out(f"{w.experiment_name}/demux_reads_scatter/")
     message:
         "Combining the sample-specific fastq.fz files ({wildcards.experiment_name})."
     shell:

--- a/workflow/rules/step3_alignment.smk
+++ b/workflow/rules/step3_alignment.smk
@@ -9,20 +9,20 @@
 
 rule trim_fastp:
     input:
-        R1="{dir_output}/{experiment_name}/demux_reads/{sample_name}_R1.fastq.gz",
-        R2="{dir_output}/{experiment_name}/demux_reads/{sample_name}_R2.fastq.gz",
+        R1=out("{experiment_name}/demux_reads/{sample_name}_R1.fastq.gz"),
+        R2=out("{experiment_name}/demux_reads/{sample_name}_R2.fastq.gz"),
     output:
-        R1=temp("{dir_output}/{experiment_name}/fastp/{sample_name}_R1.fastq.gz"),
-        R2=temp("{dir_output}/{experiment_name}/fastp/{sample_name}_R2.fastq.gz"),
-        html="{dir_output}/{experiment_name}/fastp/{sample_name}.html",
-        json="{dir_output}/{experiment_name}/fastp/{sample_name}.json",
+        R1=temp(out("{experiment_name}/fastp/{sample_name}_R1.fastq.gz")),
+        R2=temp(out("{experiment_name}/fastp/{sample_name}_R2.fastq.gz")),
+        html=out("{experiment_name}/fastp/{sample_name}.html"),
+        json=out("{experiment_name}/fastp/{sample_name}.json"),
     log:
-        "{dir_output}/logs/step3_alignment/fastp_{experiment_name}_{sample_name}.log",
+        out("logs/step3_alignment/fastp_{experiment_name}_{sample_name}.log"),
     threads: 10
     resources:
         mem_mb=1024 * 4,
     benchmark:
-        "{dir_output}/benchmarks/trim_fastp_{experiment_name}_{sample_name}.txt"
+        out("benchmarks/{experiment_name}/trim_fastp_{sample_name}.txt")
     params:
         extra=config["settings"]["fastp"],
     conda:
@@ -41,14 +41,14 @@ def get_expected_cells(wildcards):
 
 rule generate_index_STAR:
     output:
-        directory("{dir_output}/resources/index_star/{species}"),
+        directory(out("resources/index_star/{species}")),
     log:
-        "{dir_output}/logs/step3_alignment/generate_index_STAR_{species}.log",
+        out("logs/step3_alignment/generate_index_STAR_{species}.log"),
     threads: 20
     resources:
         mem_mb=1024 * 50,
     benchmark:
-        "{dir_output}/benchmarks/generate_index_STAR_{species}.txt"
+        out("benchmarks/generate_index_STAR_{species}.txt")
     params:
         fasta=lambda w: config["species"][w.species]["genome"],
         gtf=lambda w: config["species"][w.species]["genome_gtf"],
@@ -70,40 +70,40 @@ rule generate_index_STAR:
 
 rule starSolo_align:
     input:
-        R1="{dir_output}/{experiment_name}/fastp/{sample_name}_R1.fastq.gz",
-        R2="{dir_output}/{experiment_name}/fastp/{sample_name}_R2.fastq.gz",
-        index="{dir_output}/resources/index_star/{species}/",
-        whitelist_p7="{dir_output}/{experiment_name}/demux_reads/{experiment_name}_whitelist_p7.txt",
-        whitelist_p5="{dir_output}/{experiment_name}/demux_reads/{experiment_name}_whitelist_p5.txt",
-        whitelist_ligation="{dir_output}/{experiment_name}/demux_reads/{experiment_name}_whitelist_ligation.txt",
-        whitelist_rt="{dir_output}/{experiment_name}/demux_reads/{experiment_name}_whitelist_rt.txt",
+        R1=out("{experiment_name}/fastp/{sample_name}_R1.fastq.gz"),
+        R2=out("{experiment_name}/fastp/{sample_name}_R2.fastq.gz"),
+        index=out("resources/index_star/{species}/"),
+        whitelist_p7=out("{experiment_name}/demux_reads/{experiment_name}_whitelist_p7.txt"),
+        whitelist_p5=out("{experiment_name}/demux_reads/{experiment_name}_whitelist_p5.txt"),
+        whitelist_ligation=out("{experiment_name}/demux_reads/{experiment_name}_whitelist_ligation.txt"),
+        whitelist_rt=out("{experiment_name}/demux_reads/{experiment_name}_whitelist_rt.txt"),
     output:
-        bam="{dir_output}/{experiment_name}/alignment/{sample_name}_{species}_Aligned.sortedByCoord.out.bam",
-        sj="{dir_output}/{experiment_name}/alignment/{sample_name}_{species}_SJ.out.tab",
-        log1="{dir_output}/{experiment_name}/alignment/{sample_name}_{species}_Log.final.out",
-        log2=temp("{dir_output}/{experiment_name}/alignment/{sample_name}_{species}_Log.out"),
+        bam=out("{experiment_name}/alignment/{sample_name}_{species}_Aligned.sortedByCoord.out.bam"),
+        sj=out("{experiment_name}/alignment/{sample_name}_{species}_SJ.out.tab"),
+        log1=out("{experiment_name}/alignment/{sample_name}_{species}_Log.final.out"),
+        log2=temp(out("{experiment_name}/alignment/{sample_name}_{species}_Log.out")),
         log3=temp(
-            "{dir_output}/{experiment_name}/alignment/{sample_name}_{species}_Log.progress.out"
+            out("{experiment_name}/alignment/{sample_name}_{species}_Log.progress.out")
         ),
         dir_tmp=temp(
-            directory("{dir_output}/{experiment_name}/alignment/{sample_name}_{species}__STARtmp/")
+            directory(out("{experiment_name}/alignment/{sample_name}_{species}__STARtmp"))
         ),
         dir_solo=directory(
-            "{dir_output}/{experiment_name}/alignment/{sample_name}_{species}_Solo.out/"
+            out("{experiment_name}/alignment/{sample_name}_{species}_Solo.out")
         ),
-        barcodes_raw="{dir_output}/{experiment_name}/alignment/{sample_name}_{species}_Solo.out/GeneFull_Ex50pAS/raw/barcodes.tsv",
-        barcodes_raw_converted="{dir_output}/{experiment_name}/alignment/{sample_name}_{species}_Solo.out/GeneFull_Ex50pAS/raw/barcodes_converted.tsv",
-        barcodes_filtered="{dir_output}/{experiment_name}/alignment/{sample_name}_{species}_Solo.out/GeneFull_Ex50pAS/filtered/barcodes.tsv",
-        barcodes_filtered_converted="{dir_output}/{experiment_name}/alignment/{sample_name}_{species}_Solo.out/GeneFull_Ex50pAS/filtered/barcodes_converted.tsv",
+        barcodes_raw=out("{experiment_name}/alignment/{sample_name}_{species}_Solo.out/GeneFull_Ex50pAS/raw/barcodes.tsv"),
+        barcodes_raw_converted=out("{experiment_name}/alignment/{sample_name}_{species}_Solo.out/GeneFull_Ex50pAS/raw/barcodes_converted.tsv"),
+        barcodes_filtered=out("{experiment_name}/alignment/{sample_name}_{species}_Solo.out/GeneFull_Ex50pAS/filtered/barcodes.tsv"),
+        barcodes_filtered_converted=out("{experiment_name}/alignment/{sample_name}_{species}_Solo.out/GeneFull_Ex50pAS/filtered/barcodes_converted.tsv"),
     log:
-        "{dir_output}/logs/step3_alignment/star_align_{experiment_name}_{sample_name}_{species}.log",
+        out("logs/step3_alignment/star_align_{experiment_name}_{sample_name}_{species}.log"),
     threads: 30
     resources:
         mem_mb=1024 * 60,
     benchmark:
-        "{dir_output}/benchmarks/starSolo_align_{experiment_name}_{sample_name}_{species}.txt"
+        out("benchmarks/{experiment_name}/starSolo_align_{sample_name}_{species}.txt")
     params:
-        sampleName="{dir_output}/{experiment_name}/alignment/{sample_name}_{species}_",
+        sampleName=out("{experiment_name}/alignment/{sample_name}_{species}_"),
         extra=config["settings"]["star"],
         path_barcodes=config["path_barcodes"],
         n_expected_cells=lambda w: get_expected_cells(w),
@@ -132,16 +132,16 @@ rule starSolo_align:
 
 rule sambamba_index:
     input:
-        "{dir_output}/{experiment_name}/alignment/{sample_name}_{species}_Aligned.sortedByCoord.out.bam",
+        out("{experiment_name}/alignment/{sample_name}_{species}_Aligned.sortedByCoord.out.bam"),
     output:
-        "{dir_output}/{experiment_name}/alignment/{sample_name}_{species}_Aligned.sortedByCoord.out.bam.bai",
+        out("{experiment_name}/alignment/{sample_name}_{species}_Aligned.sortedByCoord.out.bam.bai"),
     log:
-        "{dir_output}/logs/step3_alignment/sambamba_index_{experiment_name}_{sample_name}_{species}.log",
+        out("logs/step3_alignment/sambamba_index_{experiment_name}_{sample_name}_{species}.log"),
     threads: 8
     resources:
         mem_mb=1024 * 2,
     benchmark:
-        "{dir_output}/benchmarks/sambamba_index_{experiment_name}_{sample_name}_{species}.txt"
+        out("benchmarks/{experiment_name}/sambamba_index_{sample_name}_{species}.txt")
     conda:
         "envs/sci-rocket.yaml",
     message:

--- a/workflow/rules/step4_dashboard.smk
+++ b/workflow/rules/step4_dashboard.smk
@@ -6,25 +6,27 @@
 # Get the samples for a given sequencing run (and sci-dash).
 def getsamples_sequencing(wildcards):
     df = samples_unique[samples_unique["experiment_name"] == wildcards.experiment_name]
-    files = [f"{dir_output}/{s.experiment_name}/alignment/{s.sample_name}_{s.species}_Aligned.sortedByCoord.out.bam.bai" for s in df.itertuples(index=False, name='Row')]
+    files = [out(f"{s.experiment_name}/alignment/{s.sample_name}_{s.species}_Aligned.sortedByCoord.out.bam.bai") for s in df.itertuples(index=False, name='Row')]
 
     return files
 
 rule sci_dash:
     input:
         lambda w: getsamples_sequencing(w),
-        qc="{dir_output}/{experiment_name}/demux_reads/{experiment_name}_qc.pickle"
+        qc=out("{experiment_name}/demux_reads/{experiment_name}_qc.pickle"),
     output:
-        dash_folder=directory("{dir_output}/{experiment_name}/sci-dash/"),
-        dash_json="{dir_output}/{experiment_name}/sci-dash/js/qc_data.js",
+        dash_folder=directory(out("{experiment_name}/sci-dash/")),
+        dash_json=out("{experiment_name}/sci-dash/js/qc_data.js"),
     threads: 1
     resources:
         mem_mb=1024 * 10,
     benchmark:
-        "{dir_output}/benchmarks/sci_dash_{experiment_name}.txt"
+        out("benchmarks/{experiment_name}/sci_dash.txt")
     params:
+        path_star=out("{experiment_name}/alignment/"),
         # Optional hashing output. 
-        metrics_hashing="{dir_output}/{experiment_name}/hashing/{experiment_name}_hashing_metrics.tsv"
+        metrics_hashing=out("{experiment_name}/hashing/{experiment_name}_hashing_metrics.tsv"),
+        benchmarks_folder=out("benchmarks/{experiment_name}")
     conda:
         "envs/sci-rocket.yaml",
     message:
@@ -38,8 +40,9 @@ rule sci_dash:
         python3 {workflow.basedir}/rules/scripts/demultiplexing/demux_dash.py \
         --path_out {output.dash_json} \
         --path_pickle {input.qc} \
-        --path_star {dir_output}/{wildcards.experiment_name}/alignment/ \
-        --path_hashing {params.metrics_hashing}
+        --path_star {params.path_star} \
+        --path_hashing {params.metrics_hashing} \
+        --path_benchmarks {params.benchmarks_folder}
 
         # Remove all empty (leftover) folders.
         find {dir_output}/{wildcards.experiment_name}/ -empty -type d -delete

--- a/workflow/rules/step5_haplotyping.smk
+++ b/workflow/rules/step5_haplotyping.smk
@@ -16,13 +16,13 @@
 
 rule mgp_download:
     output:
-        mgp_snp=temp("{dir_output}/resources/MGP/mgp_REL2021_snps.vcf.gz"),
-        mgp_snp_idx=temp("{dir_output}/resources/MGP/mgp_REL2021_snps.vcf.gz.csi"),
-        mgp_indel=temp("{dir_output}/resources/MGP/mgp_REL2021_indels.vcf.gz"),
-        mgp_indel_idx=temp("{dir_output}/resources/MGP/mgp_REL2021_indels.vcf.gz.csi"),
-        mgp_combined=temp("{dir_output}/resources/MGP/mgp_REL2021_snps_indels.vcf.gz"),
+        mgp_snp=temp(out("resources/MGP/mgp_REL2021_snps.vcf.gz")),
+        mgp_snp_idx=temp(out("resources/MGP/mgp_REL2021_snps.vcf.gz.csi")),
+        mgp_indel=temp(out("resources/MGP/mgp_REL2021_indels.vcf.gz")),
+        mgp_indel_idx=temp(out("resources/MGP/mgp_REL2021_indels.vcf.gz.csi")),
+        mgp_combined=temp(out("resources/MGP/mgp_REL2021_snps_indels.vcf.gz")),
     log:
-        "{dir_output}/logs/haplotyping/prepare_mgp.log",
+        out("logs/haplotyping/prepare_mgp.log"),
     threads: 10
     params:
         path_mgp=config["path_mgp"],
@@ -54,10 +54,10 @@ rule mgp_download:
 
 rule mgp_chr_prefix:
     input:
-        "{dir_output}/resources/MGP/mgp_REL2021_snps_indels.vcf.gz",
+        out("resources/MGP/mgp_REL2021_snps_indels.vcf.gz"),
     output:
-        vcf="{dir_output}/resources/MGP/mgp_REL2021_snps_indels_chr_prefix.vcf.gz",
-        tbi="{dir_output}/resources/MGP/mgp_REL2021_snps_indels_chr_prefix.vcf.gz.tbi",
+        vcf=out("resources/MGP/mgp_REL2021_snps_indels_chr_prefix.vcf.gz"),
+        tbi=out("resources/MGP/mgp_REL2021_snps_indels_chr_prefix.vcf.gz.tbi"),
     threads: 8
     conda:
         "envs/sci-haplotyping.yaml",
@@ -79,17 +79,17 @@ rule mgp_chr_prefix:
 
 rule generate_hybrid_vcf:
     input:
-        mgp="{dir_output}/resources/MGP/mgp_REL2021_snps_indels_chr_prefix.vcf.gz",
-        mgp_index="{dir_output}/resources/MGP/mgp_REL2021_snps_indels_chr_prefix.vcf.gz.tbi",
+        mgp=out("resources/MGP/mgp_REL2021_snps_indels_chr_prefix.vcf.gz"),
+        mgp_index=out("resources/MGP/mgp_REL2021_snps_indels_chr_prefix.vcf.gz.tbi"),
     output:
-        vcf=temp("{dir_output}/resources/MGP/{strain1}_{strain2}_hybrid.vcf.gz"),
+        vcf=temp(out("resources/MGP/{strain1}_{strain2}_hybrid.vcf.gz")),
     log:
-        "{dir_output}/logs/haplotyping/generate_hybrid_vcf_{strain1}_{strain2}.log",
+        out("logs/haplotyping/generate_hybrid_vcf_{strain1}_{strain2}.log"),
     threads: 2
     resources:
         mem_mb=1024 * 2,
     benchmark:
-        "{dir_output}/benchmarks/generate_hybrid_vcf_{strain1}_{strain2}.txt"
+        out("benchmarks/generate_hybrid_vcf_{strain1}_{strain2}.txt")
     conda:
         "envs/sci-haplotyping.yaml",
     message:
@@ -125,15 +125,15 @@ rule generate_hybrid_vcf:
 
 rule normalize_hybrid_vcf:
     input:
-        vcf="{dir_output}/resources/MGP/{strain1}_{strain2}_hybrid.vcf.gz",
+        vcf=out("resources/MGP/{strain1}_{strain2}_hybrid.vcf.gz"),
     output:
-        vcf=temp("{dir_output}/resources/MGP/{strain1}_{strain2}_hybrid_norm.vcf.gz"),
-        idx=temp("{dir_output}/resources/MGP/{strain1}_{strain2}_hybrid_norm.vcf.gz.tbi"),
+        vcf=temp(out("resources/MGP/{strain1}_{strain2}_hybrid_norm.vcf.gz")),
+        idx=temp(out("resources/MGP/{strain1}_{strain2}_hybrid_norm.vcf.gz.tbi")),
     threads: 1
     params:
         fasta=lambda w: config["species"]["mouse"]["genome"],
     benchmark:
-        "{dir_output}/benchmarks/normalize_hybrid_vcf_{strain1}_{strain2}.txt"
+        out("benchmarks/normalize_hybrid_vcf_{strain1}_{strain2}.txt")
     conda:
         "envs/sci-haplotyping.yaml",
     message:
@@ -151,8 +151,8 @@ rule normalize_hybrid_vcf:
 
 rule download_repeatmasker:
     output:
-        repeatmasker=temp("{dir_output}/resources/MGP/rmsk.bed"),
-        rmsk=temp("{dir_output}/resources/MGP/rmsk.txt.gz"),
+        repeatmasker=temp(out("resources/MGP/rmsk.bed")),
+        rmsk=temp(out("resources/MGP/rmsk.txt.gz")),
     threads: 1
     resources:
         mem_mb=1024 * 2,
@@ -172,12 +172,12 @@ rule download_repeatmasker:
 
 rule filter_repeatmasker:
     input:
-        vcf="{dir_output}/resources/MGP/{strain1}_{strain2}_hybrid_norm.vcf.gz",
-        idx="{dir_output}/resources/MGP/{strain1}_{strain2}_hybrid_norm.vcf.gz.tbi",
-        repeatmasker="{dir_output}/resources/MGP/rmsk.bed",
+        vcf=out("resources/MGP/{strain1}_{strain2}_hybrid_norm.vcf.gz"),
+        idx=out("resources/MGP/{strain1}_{strain2}_hybrid_norm.vcf.gz.tbi"),
+        repeatmasker=out("resources/MGP/rmsk.bed"),
     output:
-        vcf="{dir_output}/resources/MGP/{strain1}_{strain2}_hybrid_norm_SNPs_norepeats.vcf.gz",
-        idx="{dir_output}/resources/MGP/{strain1}_{strain2}_hybrid_norm_SNPs_norepeats.vcf.gz.tbi",
+        vcf=out("resources/MGP/{strain1}_{strain2}_hybrid_norm_SNPs_norepeats.vcf.gz"),
+        idx=out("resources/MGP/{strain1}_{strain2}_hybrid_norm_SNPs_norepeats.vcf.gz.tbi"),
     threads: 1
     conda:
         "envs/sci-haplotyping.yaml",
@@ -189,19 +189,19 @@ rule filter_repeatmasker:
 
 rule run_haplotag:
     input:
-        bam="{dir_output}/{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.bam",
-        vcf="{dir_output}/resources/MGP/{strain1}_{strain2}_hybrid_norm_SNPs_norepeats.vcf.gz",
-        idx="{dir_output}/resources/MGP/{strain1}_{strain2}_hybrid_norm_SNPs_norepeats.vcf.gz.tbi",
+        bam=out("{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.bam"),
+        vcf=out("resources/MGP/{strain1}_{strain2}_hybrid_norm_SNPs_norepeats.vcf.gz"),
+        idx=out("resources/MGP/{strain1}_{strain2}_hybrid_norm_SNPs_norepeats.vcf.gz.tbi"),
     output:
-        bam="{dir_output}/{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam",
-        bai="{dir_output}/{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam.bai",
+        bam=out("{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam"),
+        bai=out("{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam.bai"),
     log:
-        "{dir_output}/logs/haplotyping/haplotag_{experiment_name}_{sample_name}_{strain1}_{strain2}.log",
+        out("logs/haplotyping/haplotag_{experiment_name}_{sample_name}_{strain1}_{strain2}.log"),
     threads: 10
     resources:
         mem_mb=1024 * 40,
     benchmark:
-        "{dir_output}/benchmarks/run_haplotag_{strain1}_{strain2}_{experiment_name}_{sample_name}.txt"
+        out("benchmarks/{experiment_name}/run_haplotag_{strain1}_{strain2}_{sample_name}.txt")
     params:
         fasta=lambda w: config["species"]["mouse"]["genome"],
     conda:
@@ -220,16 +220,16 @@ rule run_haplotag:
 
 rule haplotype_split_h1:
     input:
-        bam="{dir_output}/{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam",
-        bai="{dir_output}/{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam.bai",
+        bam=out("{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam"),
+        bai=out("{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam.bai"),
     output:
-        bam=temp("{dir_output}/{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_h1.bam"),
-        bai=temp("{dir_output}/{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_h1.bam.bai"),
+        bam=temp(out("{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_h1.bam")),
+        bai=temp(out("{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_h1.bam.bai")),
     threads: 10
     resources:
         mem_mb=1024 * 10,
     benchmark:
-        "{dir_output}/benchmarks/haplotype_split_h1_{strain1}_{strain2}_{experiment_name}_{sample_name}.txt"
+        out("benchmarks/{experiment_name}/haplotype_split_h1_{strain1}_{strain2}_{sample_name}.txt")
     conda:
         "envs/sci-haplotyping.yaml",
     shell:
@@ -241,16 +241,16 @@ rule haplotype_split_h1:
 
 rule haplotype_split_h2:
     input:
-        bam="{dir_output}/{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam",
-        bai="{dir_output}/{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam.bai",
+        bam=out("{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam"),
+        bai=out("{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam.bai"),
     output:
-        bam=temp("{dir_output}/{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_h2.bam"),
-        bai=temp("{dir_output}/{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_h2.bam.bai"),
+        bam=temp(out("{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_h2.bam")),
+        bai=temp(out("{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_h2.bam.bai")),
     threads: 10
     resources:
         mem_mb=1024 * 10,
     benchmark:
-        "{dir_output}/benchmarks/haplotype_split_h2_{strain1}_{strain2}_{experiment_name}_{sample_name}.txt"
+        out("benchmarks/{experiment_name}/haplotype_split_h2_{strain1}_{strain2}_{sample_name}.txt")
     conda:
         "envs/sci-haplotyping.yaml",
     shell:
@@ -262,16 +262,16 @@ rule haplotype_split_h2:
 
 rule haplotype_split_ua:
     input:
-        bam="{dir_output}/{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam",
-        bai="{dir_output}/{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam.bai",
+        bam=out("{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam"),
+        bai=out("{experiment_name}/alignment/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX.bam.bai"),
     output:
-        bam=temp("{dir_output}/{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_ua.bam"),
-        bai=temp("{dir_output}/{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_ua.bam.bai"),
+        bam=temp(out("{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_ua.bam")),
+        bai=temp(out("{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_ua.bam.bai")),
     threads: 10
     resources:
         mem_mb=1024 * 10,
     benchmark:
-        "{dir_output}/benchmarks/haplotype_split_ua_{strain1}_{strain2}_{experiment_name}_{sample_name}.txt"
+        out("benchmarks/{experiment_name}/haplotype_split_ua_{strain1}_{strain2}_{sample_name}.txt")
     conda:
         "envs/sci-haplotyping.yaml",
     shell:
@@ -282,11 +282,11 @@ rule haplotype_split_ua:
 
 rule filter_barcodes_reads:
     input:
-        bam="{dir_output}/{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_{type}.bam",
-        bai="{dir_output}/{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_{type}.bam.bai"
+        bam=out("{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_{type}.bam"),
+        bai=out("{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_{type}.bam.bai")
     output:
-        bam=temp("{dir_output}/{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_{type}_fixed.bam"),
-        bai=temp("{dir_output}/{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_{type}_fixed.bam.bai")
+        bam=temp(out("{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_{type}_fixed.bam")),
+        bai=temp(out("{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_{type}_fixed.bam.bai"))
     threads: 2
     resources:
         mem_mb=1024 * 10,
@@ -300,17 +300,17 @@ rule filter_barcodes_reads:
 
 rule count_haplotagged_reads:
     input:
-        bam="{dir_output}/{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_{type}_fixed.bam",
-        bai="{dir_output}/{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_{type}_fixed.bam.bai"
+        bam=out("{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_{type}_fixed.bam"),
+        bai=out("{experiment_name}/haplotyping/{sample_name}_mouse_Aligned.sortedByCoord.out.haplotagged_{strain1}_{strain2}.chrX_{type}_fixed.bam.bai")
     output:
-        counts=temp("{dir_output}/{experiment_name}/haplotyping/{sample_name}_{strain1}_{strain2}_haplotagged_readcounts_{type}.txt"),
+        counts=temp(out("{experiment_name}/haplotyping/{sample_name}_{strain1}_{strain2}_haplotagged_readcounts_{type}.txt")),
     log:
-        "{dir_output}/logs/haplotyping/count_haplotagged_reads_{experiment_name}_{sample_name}_{strain1}_{strain2}_{type}.log",
+        out("logs/haplotyping/count_haplotagged_reads_{experiment_name}_{sample_name}_{strain1}_{strain2}_{type}.log"),
     threads: 2
     resources:
         mem_mb=1024 * 10,
     benchmark:
-        "{dir_output}/benchmarks/count_haplotagged_reads_{strain1}_{strain2}_{experiment_name}_{sample_name}_{type}.txt"
+        out("benchmarks/{experiment_name}/count_haplotagged_reads_{strain1}_{strain2}_{sample_name}_{type}.txt")
     conda:
         "envs/sci-haplotyping.yaml",
     message:
@@ -323,18 +323,18 @@ rule count_haplotagged_reads:
 
 rule join_counts:
     input:
-        counts_h1="{dir_output}/{experiment_name}/haplotyping/{sample_name}_{strain1}_{strain2}_haplotagged_readcounts_h1.txt",
-        counts_h2="{dir_output}/{experiment_name}/haplotyping/{sample_name}_{strain1}_{strain2}_haplotagged_readcounts_h2.txt",
-        counts_ua="{dir_output}/{experiment_name}/haplotyping/{sample_name}_{strain1}_{strain2}_haplotagged_readcounts_ua.txt",
+        counts_h1=out("{experiment_name}/haplotyping/{sample_name}_{strain1}_{strain2}_haplotagged_readcounts_h1.txt"),
+        counts_h2=out("{experiment_name}/haplotyping/{sample_name}_{strain1}_{strain2}_haplotagged_readcounts_h2.txt"),
+        counts_ua=out("{experiment_name}/haplotyping/{sample_name}_{strain1}_{strain2}_haplotagged_readcounts_ua.txt"),
     output:
-        counts="{dir_output}/{experiment_name}/haplotyping/{sample_name}_{strain1}_{strain2}_haplotagged_readcounts.txt",
+        counts=out("{experiment_name}/haplotyping/{sample_name}_{strain1}_{strain2}_haplotagged_readcounts.txt"),
     log:
-        "{dir_output}/logs/haplotyping/retrieve_counts_{experiment_name}_{sample_name}_{strain1}_{strain2}.log",
+        out("logs/haplotyping/retrieve_counts_{experiment_name}_{sample_name}_{strain1}_{strain2}.log"),
     threads: 1
     resources:
         mem_mb=1024 * 20,
     benchmark:
-        "{dir_output}/benchmarks/join_counts_{strain1}_{strain2}_{experiment_name}_{sample_name}.txt"
+        out("benchmarks/{experiment_name}/join_counts_{strain1}_{strain2}_{sample_name}.txt")
     params:
         path_barcodes=config["path_barcodes"],
     conda:

--- a/workflow/scirocket-dash/index.html
+++ b/workflow/scirocket-dash/index.html
@@ -205,6 +205,9 @@
                         <a href="#tabs-uncorrectables" class="nav-link" data-bs-toggle="tab">Uncorrectable barcodes</a>
                       </li>
                       <li class="nav-item">
+                        <a href="#tabs-benchmarks" class="nav-link" data-bs-toggle="tab">Benchmarks</a>
+                      </li>
+                      <li class="nav-item">
                         <a href="#tabs-data" class="nav-link" data-bs-toggle="tab">Sci-dash data (JSON)</a>
                       </li>
                     </ul>
@@ -434,6 +437,21 @@
                         </div>
                       </div>
                       <!--End - Tab: Uncorrectable barcodes-->
+                      <!--Tab: Benchmarks-->
+                      <div class="tab-pane" id="tabs-benchmarks">
+                        <div class="container">
+                          <div class="row">
+                            <div class="card">
+                              <div class="card-body">
+                                <div id="table-default" class="table-responsive">
+                                  <table class="table" id="benchmarks-table"></table>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <!--End Tab: Benchmarks-->
                       <!--Tab: Data-->
                       <div class="tab-pane" id="tabs-data">
                         <div class="container">

--- a/workflow/scirocket-dash/js/sci_dash.js
+++ b/workflow/scirocket-dash/js/sci_dash.js
@@ -749,7 +749,7 @@ function generate_benchmarks_table(benchmarks) {
   if (!Array.isArray(benchmarks) || benchmarks.length === 0) {
     const row = tbody.insertRow(-1);
     const cell = row.insertCell(0);
-    cell.colSpan = 11;
+    cell.colSpan = 7;
     cell.style.textAlign = "center";
     cell.innerHTML = "<b>No benchmark data available</b>";
     return;

--- a/workflow/scirocket-dash/js/sci_dash.js
+++ b/workflow/scirocket-dash/js/sci_dash.js
@@ -716,6 +716,88 @@ document.addEventListener("DOMContentLoaded", function () {
 
 });
 
+//--------------------------------------------
+// Table - Benchmarks summary (like Hashing table).
+//--------------------------------------------
+
+function generate_benchmarks_table(benchmarks) {
+  const table = document.getElementById("benchmarks-table");
+  if (!table) return;
+
+  // Give it the same behavior hooks as hashing
+  table.className = "table card-table table-vcenter text-nowrap datatable tablesorter";
+
+  // Base skeleton (same style approach as hashing)
+  table.innerHTML = `
+      <thead>
+        <tr>
+          <th>Job</th>
+          <th>Time<br><sub>(seconds)</sub></th>
+          <th>Time<br><sub>(h:m:s)</sub></th>
+          <th>Max RAM<br><sub>(gb)</sub></th>
+          <th>IO Read<br><sub>(gb)</sub></th>
+          <th>IO Write<br><sub>(gb)</sub></th>
+          <th>Mean Load<br><sub>(cpus)</sub></th>
+        </tr>
+      </thead>
+      <tbody class="table-tbody"></tbody>
+    `;
+
+  const tbody = table.querySelector("tbody");
+
+  // No data case
+  if (!Array.isArray(benchmarks) || benchmarks.length === 0) {
+    const row = tbody.insertRow(-1);
+    const cell = row.insertCell(0);
+    cell.colSpan = 11;
+    cell.style.textAlign = "center";
+    cell.innerHTML = "<b>No benchmark data available</b>";
+    return;
+  }
+
+  const fmt_number = (v, digits = 1,  divide_by = 1) => {
+    if (v == null) return "N/A";
+    if (typeof v === "number") {
+      if (Number.isNaN(v)) return "N/A";
+      return (v/divide_by).toFixed(digits);
+    }
+    return String(v);
+  };
+
+  // Fill rows
+  for (const b of benchmarks) {
+    const row = tbody.insertRow(-1);
+
+    // Job name
+    row.insertCell(-1).textContent = b.job ?? "N/A";
+
+    // Time (seconds)
+    row.insertCell(-1).textContent = fmt_number(b.s, 0);
+
+    // Time (h:m:s)
+    row.insertCell(-1).textContent = b["h:m:s"] ?? "N/A";
+
+    // MB values that should be converted to GB for display
+    const fields = ["max_rss","io_in","io_out"];
+    for (const key of fields) {
+      row.insertCell(-1).textContent = fmt_number(b[key], 2, 1024);
+    }
+
+    // Load (convert percentage to cpus)
+    row.insertCell(-1).textContent = fmt_number(b.mean_load, 1, 100);
+  }
+
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+  generate_benchmarks_table(data.benchmarks);
+
+  $("#benchmarks-table").tablesorter({
+    sortList: [[1, 1]],  // default: seconds descending
+  });
+});
+
+
 
 //--------------------------------------------
 // Chart - Sankey diagram of barcodes.


### PR DESCRIPTION
- include common jobs that are used by all experiments
- exclude jobs from other experiments
- related rule refactoring
  - add benchmark output to more jobs
  - put benchmarks for each experiment in their own folder
- unrelated rule refactoring
  - add LRU cache stats to log output of sciseq_sample_demultiplexing (dominates RAM use for this job)
  - inline trivial rules that construct the fake bcl/aviti sample sheets into reads2fastq
  - use bases2fastq if found on path instead of downloading it
  - reduce core count for bases2fastq according to RAM requirements in docs (6GB/core)
  - add out() helper function to prepend dir_output to paths in rules