### PR TITLE
Fix generation of discarded barcodes logs

### DIFF
--- a/tests/test_bcl_one_run/tests/test_demux.py
+++ b/tests/test_bcl_one_run/tests/test_demux.py
@@ -1,4 +1,8 @@
 from pathlib import Path
+import csv
+import gzip
+import pickle
+from collections import Counter
 import pytest
 
 
@@ -8,3 +12,214 @@ def test_demux_output_files_exist(sample: str):
     assert demux_path.exists()
     assert (demux_path / f"{sample}_R1.fastq.gz").exists()
     assert (demux_path / f"{sample}_R2.fastq.gz").exists()
+
+
+def _read_whitelist(path: Path) -> set[str]:
+    with open(path, "r", encoding="utf-8") as handle:
+        return {line.strip() for line in handle if line.strip()}
+
+
+def _read_barcodes(path: Path, barcode_type: str) -> dict[str, str]:
+    barcodes = {}
+    with open(path, "r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        for row in reader:
+            if row["type"] == barcode_type:
+                barcodes[row["barcode"]] = row["sequence"].strip()
+    return barcodes
+
+
+def _reverse_complement(sequence: str) -> str:
+    return sequence[::-1].translate(str.maketrans("ATCG", "TAGC"))
+
+
+def _read_fastq_names(path: Path) -> list[str]:
+    names = []
+    with gzip.open(path, "rt", encoding="utf-8") as handle:
+        for i, line in enumerate(handle):
+            if i % 4 == 0:
+                header = line.rstrip("\n")
+                assert header.startswith("@")
+                names.append(header[1:].split(" ", 1)[0])
+    return names
+
+
+def _count_fastq_reads(path: Path) -> int:
+    with gzip.open(path, "rt", encoding="utf-8") as handle:
+        return sum(1 for _ in handle) // 4
+
+
+def _iter_fastq_sequences(path: Path):
+    with gzip.open(path, "rt", encoding="utf-8") as handle:
+        for i, line in enumerate(handle):
+            if i % 4 == 1:
+                yield line.rstrip("\n")
+
+
+def test_demux_whitelists_subset_of_configured_barcodes():
+    test_root = Path(__file__).parent.parent
+    demux_path = test_root / "output" / "zfish" / "demux_reads"
+    barcodes_path = test_root.parent / "barcodes_bcl.tsv"
+
+    whitelist_p5 = _read_whitelist(demux_path / "zfish_whitelist_p5.txt")
+    whitelist_p7 = _read_whitelist(demux_path / "zfish_whitelist_p7.txt")
+    whitelist_ligation = _read_whitelist(demux_path / "zfish_whitelist_ligation.txt")
+    whitelist_rt = _read_whitelist(demux_path / "zfish_whitelist_rt.txt")
+
+    barcodes_p5 = _read_barcodes(barcodes_path, "p5")
+    barcodes_p7 = _read_barcodes(barcodes_path, "p7")
+    barcodes_ligation = _read_barcodes(barcodes_path, "ligation")
+    barcodes_rt = _read_barcodes(barcodes_path, "rt")
+
+    # Sample sheet uses p5 A03:H03, so include A03/H03 and exclude A01/A12.
+    assert _reverse_complement(barcodes_p5["A03"]) in whitelist_p5
+    assert _reverse_complement(barcodes_p5["H03"]) in whitelist_p5
+    assert _reverse_complement(barcodes_p5["A01"]) not in whitelist_p5
+    assert _reverse_complement(barcodes_p5["A12"]) not in whitelist_p5
+
+    # Sample sheet uses p7 C01:C12, so include C01/C12 and exclude A01/B01.
+    assert barcodes_p7["C01"] in whitelist_p7
+    assert barcodes_p7["C12"] in whitelist_p7
+    assert barcodes_p7["A01"] not in whitelist_p7
+    assert barcodes_p7["B01"] not in whitelist_p7
+
+    # Ligation whitelist should include all ligation barcodes from barcodes_bcl.tsv,
+    # with 9nt barcodes padded to 10nt by appending "G".
+    expected_ligation = {
+        sequence if len(sequence) == 10 else sequence + "G"
+        for sequence in barcodes_ligation.values()
+    }
+    assert whitelist_ligation == expected_ligation
+    assert all(len(sequence) == 10 for sequence in whitelist_ligation)
+    assert "ACTTGATTGT" in whitelist_ligation
+    assert "GGCGTTAATG" in whitelist_ligation
+    assert "GGCGTTAAT" not in whitelist_ligation
+    assert "AAAAAAAAAA" not in whitelist_ligation
+
+    # Sample sheet uses RT P01-{A..H}{01..07}, so include in-range and exclude out-of-range.
+    assert barcodes_rt["P01-A01"] in whitelist_rt
+    assert barcodes_rt["P01-H07"] in whitelist_rt
+    assert barcodes_rt["P01-A08"] not in whitelist_rt
+    assert barcodes_rt["P02-A01"] not in whitelist_rt
+
+
+def test_discarded_logs_consistent_with_discarded_fastqs():
+    demux_path = Path(__file__).parent.parent / "output" / "zfish" / "demux_reads"
+    path_log = demux_path / "log_zfish_discarded_reads.tsv.gz"
+    path_r1 = demux_path / "zfish_R1_discarded.fastq.gz"
+    path_r2 = demux_path / "zfish_R2_discarded.fastq.gz"
+
+    assert path_log.exists()
+    assert path_r1.exists()
+    assert path_r2.exists()
+
+    with gzip.open(path_log, "rt", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        assert reader.fieldnames == ["read_name", "p5", "p7", "ligation", "rt", "umi", "sample_name"]
+        rows = list(reader)
+
+    assert len(rows) > 0
+    # Merged discard logs should contain exactly one header row.
+    assert all(row["read_name"] != "read_name" for row in rows)
+    assert all(row["sample_name"] == "?" for row in rows)
+
+    observed = {(row["p5"], row["p7"], row["ligation"], row["rt"]) for row in rows}
+    # Explicit discarded examples from the fixture output.
+    assert ("ACTACTTGAG", "TCTTGAGGTT", "LIG9", "CGCTCCTAAC") in observed
+    assert ("G03", "C05", "LIG53", "GCAGACGCCT") in observed
+    assert ("F03", "ATGGCAGATA", "LIG14", "P01-E02") in observed
+
+    n_reads_r1 = _count_fastq_reads(path_r1)
+    n_reads_r2 = _count_fastq_reads(path_r2)
+
+    assert len(rows) == n_reads_r1 == n_reads_r2
+
+
+def test_discarded_log_read_names_match_discarded_fastqs():
+    demux_path = Path(__file__).parent.parent / "output" / "zfish" / "demux_reads"
+    path_log = demux_path / "log_zfish_discarded_reads.tsv.gz"
+    path_r1 = demux_path / "zfish_R1_discarded.fastq.gz"
+    path_r2 = demux_path / "zfish_R2_discarded.fastq.gz"
+
+    assert path_log.exists()
+    assert path_r1.exists()
+    assert path_r2.exists()
+
+    with gzip.open(path_log, "rt", encoding="utf-8", newline="") as handle:
+        log_names = [row["read_name"] for row in csv.DictReader(handle, delimiter="\t")]
+
+    assert Counter(log_names) == Counter(_read_fastq_names(path_r1))
+    assert Counter(log_names) == Counter(_read_fastq_names(path_r2))
+
+
+def test_sample_fastqs_have_paired_reads_and_r1_length_48nt():
+    test_root = Path(__file__).parent.parent
+    demux_path = test_root / "output" / "zfish" / "demux_reads"
+    samplesheet_path = test_root / "samplesheet.tsv"
+
+    with open(samplesheet_path, "r", encoding="utf-8", newline="") as handle:
+        sample_names = sorted({row["sample_name"] for row in csv.DictReader(handle, delimiter="\t")})
+
+    for sample_name in sample_names:
+        path_r1 = demux_path / f"{sample_name}_R1.fastq.gz"
+        path_r2 = demux_path / f"{sample_name}_R2.fastq.gz"
+        assert path_r1.exists()
+        assert path_r2.exists()
+
+        n_r1 = _count_fastq_reads(path_r1)
+        n_r2 = _count_fastq_reads(path_r2)
+        assert n_r1 == n_r2
+        assert all(len(seq) == 48 for seq in _iter_fastq_sequences(path_r1))
+
+
+def test_qc_pickle_consistent_with_demux_outputs():
+    demux_path = Path(__file__).parent.parent / "output" / "zfish" / "demux_reads"
+    path_qc = demux_path / "zfish_qc.pickle"
+    path_log = demux_path / "log_zfish_discarded_reads.tsv.gz"
+    path_discard_r1 = demux_path / "zfish_R1_discarded.fastq.gz"
+    path_discard_r2 = demux_path / "zfish_R2_discarded.fastq.gz"
+    path_sample_r1 = demux_path / "zfish-hash_R1.fastq.gz"
+    path_sample_r2 = demux_path / "zfish-hash_R2.fastq.gz"
+
+    assert path_qc.exists()
+    assert path_log.exists()
+    assert path_discard_r1.exists()
+    assert path_discard_r2.exists()
+    assert path_sample_r1.exists()
+    assert path_sample_r2.exists()
+
+    with open(path_qc, "rb") as handle:
+        qc = pickle.load(handle)
+
+    with gzip.open(path_log, "rt", encoding="utf-8", newline="") as handle:
+        n_discard_log_rows = sum(1 for _ in csv.DictReader(handle, delimiter="\t"))
+    n_discard_r1 = _count_fastq_reads(path_discard_r1)
+    n_discard_r2 = _count_fastq_reads(path_discard_r2)
+    n_sample_r1 = _count_fastq_reads(path_sample_r1)
+    n_sample_r2 = _count_fastq_reads(path_sample_r2)
+
+    assert qc["experiment_name"] == "zfish"
+    assert qc["n_pairs_success"] + qc["n_pairs_failure"] == qc["n_pairs"]
+
+    assert n_discard_log_rows == n_discard_r1 == n_discard_r2 == qc["n_pairs_failure"]
+    assert n_sample_r1 == n_sample_r2
+    assert qc["sample_success"]["zfish-hash"]["n_pairs_success"] == qc["n_pairs_success"]
+    assert n_sample_r1 + qc["n_hashing"] == qc["n_pairs_success"]
+    assert n_sample_r1 + n_discard_r1 + qc["n_hashing"] == qc["n_pairs"]
+
+
+def test_qc_pickle_covers_all_samples_from_samplesheet():
+    test_root = Path(__file__).parent.parent
+    demux_path = test_root / "output" / "zfish" / "demux_reads"
+    samplesheet_path = test_root / "samplesheet.tsv"
+    path_qc = demux_path / "zfish_qc.pickle"
+
+    assert path_qc.exists()
+
+    with open(samplesheet_path, "r", encoding="utf-8", newline="") as handle:
+        sample_names = {row["sample_name"] for row in csv.DictReader(handle, delimiter="\t")}
+    with open(path_qc, "rb") as handle:
+        qc = pickle.load(handle)
+
+    assert set(qc["sample_success"].keys()) == sample_names
+    assert sum(entry["n_pairs_success"] for entry in qc["sample_success"].values()) == qc["n_pairs_success"]

--- a/workflow/rules/scripts/demultiplexing/demux_gather.py
+++ b/workflow/rules/scripts/demultiplexing/demux_gather.py
@@ -121,7 +121,6 @@ def combine_scattered(path_demux_scatter, path_out):
     # Combined pickles.
     pickle.dump(qc, open(path_out, "wb"))
 
-
 def main(arguments):
     # Setup argument parser.
     parser = argparse.ArgumentParser(description="Combine the scattered pickles into a single pickle.", add_help=False)

--- a/workflow/rules/scripts/demultiplexing/demux_rocket.py
+++ b/workflow/rules/scripts/demultiplexing/demux_rocket.py
@@ -286,7 +286,6 @@ def open_file_handlers(samples: pd.DataFrame, experiment_name: str, path_r1: str
         path_r2 (str): Path to R2 fastq file.
         path_out (str): Path to output directory.
         log (logging.Logger): Logger.
-
     Returns:
         dict_fh (dict): Dictionary of file handlers.
     """
@@ -311,9 +310,6 @@ def open_file_handlers(samples: pd.DataFrame, experiment_name: str, path_r1: str
         dict_fh["r2_discarded"] = gzip.open(path_r2_discarded, "wt", compresslevel=2)
         dict_fh["discarded_log"] = gzip.open(path_log_discarded, "wt", compresslevel=2)
 
-        # Header of discard log.
-        dict_fh["discarded_log"].write("read_name\tp5\tp7\tligation\trt\tumi\tsample_name\n")
-
     except OSError:
         log.error(
             "Could not generate experiment-based discard files: Please check the paths:\n(R1 discarded) %s\n(R2 discarded) %s\n(log discarded) %s",
@@ -324,7 +320,8 @@ def open_file_handlers(samples: pd.DataFrame, experiment_name: str, path_r1: str
         sys.exit(1)
 
     # Sample-specific R1 / R2 output.
-    for sample in set(samples.sample_name):
+    output_sample_names = sorted(samples["sample_name"].unique().tolist())
+    for sample in output_sample_names:
         # Initialize the sample dictionary.
         dict_fh[sample] = {}
 
@@ -379,7 +376,15 @@ def retrieve_hashing_sheets(samples: pd.DataFrame):
     return hashing
 
 
-def sciseq_sample_demultiplexing(log: logging.Logger, experiment_name: str, samples: pd.DataFrame, barcodes: pd.DataFrame, path_r1: str, path_r2: str, path_out: str):
+def sciseq_sample_demultiplexing(
+    log: logging.Logger,
+    experiment_name: str,
+    samples: pd.DataFrame,
+    barcodes: pd.DataFrame,
+    path_r1: str,
+    path_r2: str,
+    path_out: str,
+):
     """
     Performs demultiplexing of the raw fastq files based on the PCR indexes (p5, p7) and RT barcode to produce sample-specific R1 and R2 files.
     The ligation barcode can be either 9nt or 10nt long and this can affect the location of the UMI and RT barcodes.
@@ -394,35 +399,37 @@ def sciseq_sample_demultiplexing(log: logging.Logger, experiment_name: str, samp
     Parameters:
         log (logging.Logger): Logger.
         experiment_name (str): Experiment name.
-        samples (pd.DataFrame): Sample sheet of the samples in the experiment.
+        samples (pd.DataFrame): Sample sheet.
         barcodes (pd.DataFrame): Barcode sheet.
         path_r1 (str): Path to R1 fastq file.
         path_r2 (str): Path to R2 fastq file.
         path_out (str): Path to output directory.
-
     Returns:
         None
     """
 
     log.info("Starting sample-based demultiplexing of %s:\n(R1) %s\n(R2) %s", experiment_name, path_r1, path_r2)
 
+    # Subset samples used for matching and QC in this experiment.
+    samples_exp = samples.query("experiment_name == @experiment_name")
+
     # Open the IO handlers.
     dict_fh = open_file_handlers(samples, experiment_name, path_r1, path_r2, path_out, log)
 
     # Generate the barcode dictionaries.
-    dict_barcodes = init_barcode_dict(barcodes, samples, experiment_name)
+    dict_barcodes = init_barcode_dict(barcodes, samples_exp, experiment_name)
 
     # Generate the sample dictionary.
-    dict_samples = generate_sample_dict(samples, barcodes)
+    dict_samples = generate_sample_dict(samples_exp, barcodes)
 
     # Import hashing information (if applicable)
-    dict_hashing = retrieve_hashing_sheets(samples)
+    dict_hashing = retrieve_hashing_sheets(samples_exp)
 
     if dict_hashing:
         log.info("Hashing sample(s) detected in this experiment, hashing subroutines are enabled for these samples. After counting, hash-reads are discarded.")
 
     # Initialize the QC dictionary.
-    qc = init_qc(experiment_name, dict_barcodes, samples, dict_hashing)
+    qc = init_qc(experiment_name, dict_barcodes, samples_exp, dict_hashing)
 
     # Iterate over the read-pairs and search for the barcodes within R1.
     # If any barcode is not found, try to rescue a respective barcode sequence with 1bp mismatch.
@@ -606,7 +613,6 @@ def main(arguments):
     parser.add_argument("--samples", required=True, type=str, help="(str) Path to sample-sheet.")
     parser.add_argument("--barcodes", required=True, type=str, help="(str) Path to barcodes file.")
     parser.add_argument("--out", required=True, type=str, help="(str) Path to output directory.")
-
     parser.add_argument("-h", "--help", action="help", default=argparse.SUPPRESS, help="Display help and exit.")
     parser.add_argument("-v", "--version", action="version", version=__version__, help="Display version and exit.")
 
@@ -618,7 +624,6 @@ def main(arguments):
 
     # Open sample-sheet.
     samples = pd.read_csv(args.samples, sep="\t", dtype=str)
-    samples = samples.query("experiment_name == @args.experiment_name")
 
     # Open barcode-sheet.
     barcodes = pd.read_csv(args.barcodes, sep="\t", dtype=str)
@@ -628,7 +633,15 @@ def main(arguments):
         os.makedirs(args.out)
 
     # Run the program.
-    sciseq_sample_demultiplexing(log=log, experiment_name=args.experiment_name, samples=samples, barcodes=barcodes, path_r1=args.r1, path_r2=args.r2, path_out=args.out)
+    sciseq_sample_demultiplexing(
+        log=log,
+        experiment_name=args.experiment_name,
+        samples=samples,
+        barcodes=barcodes,
+        path_r1=args.r1,
+        path_r2=args.r2,
+        path_out=args.out,
+    )
 
 
 if __name__ == "__main__":

--- a/workflow/rules/step2_demultiplexing_fastq.smk
+++ b/workflow/rules/step2_demultiplexing_fastq.smk
@@ -1,87 +1,60 @@
 #   * Generate sample-specific .fastq.gz files by demultiplexing the sci-seq barcodes. *
 #
-#   1. split_R1:                            Split the R1 file into smaller files which will be handled in parallel.
-#   2. split_R2:                            Split the R2 file into smaller files which will be handled in parallel.
-#   3. demultiplex_fastq_split:             Demultiplex each splitted R1 and R2 file to generate sample-specific fastq.gz files (in parallel).
+#   1. split_reads:                         Split R1 and R2 files into smaller files which will be handled in parallel.
+#   3. demultiplex_fastq_split:             Demultiplex each split R1 and R2 file to generate sample-specific fastq.gz files (in parallel).
 #   4. gather_demultiplexed_sequencing:     Combine the discarded and whitelist files (from multiple parallel jobs).
-#   5. gather_demultiplexed_samples:        Combine the sample-specific fastq.fz files (from multiple parallel jobs).
+#   5. gather_demultiplexed_samples:        Combine the sample-specific fastq.gz files (from multiple parallel jobs).
 #############
 
 # ---- Split R1 and R2 files into smaller files which will be handled in parallel. ----
-rule split_R1:
+rule split_reads:
     input:
-        out("{experiment_name}/raw_reads/Undetermined_S0_R1_001.fastq.gz"),
+        out("{experiment_name}/raw_reads/Undetermined_S0_{read}_001.fastq.gz"),
     output:
         temp(
             scatter.fastq_split(
-                out("{{experiment_name}}/raw_reads_split/R1_{scatteritem}.fastq.gz")
+                out("{{experiment_name}}/raw_reads_split/{{read}}_{scatteritem}.fastq.gz")
             )
         ),
+    wildcard_constraints:
+        read="R[12]",
     threads: 5
     resources:
         mem_mb=1024 * 10,
     benchmark:
-        out("benchmarks/{experiment_name}/split_R1.txt")
+        out("benchmarks/{experiment_name}/split_{read}.txt")
     params:
-        out=lambda w: [
-            "-o " +
-            out(f"{w.experiment_name}/raw_reads_split/R1_{i}-of-")
-            + str(workflow._scatter["fastq_split"])
-            + ".fastq.gz"
-            for i in range(1, workflow._scatter["fastq_split"] + 1)
-        ],
+        out_args=lambda w, output: " ".join(f"-o {path}" for path in output),
     conda:
         "envs/sci-rocket.yaml",        
     message:
-        "Generating multiple evenly-sized R1 chunks ({wildcards.experiment_name})."
+        "Generating multiple evenly-sized {wildcards.read} chunks ({wildcards.experiment_name})."
     shell:
         """
-        fastqsplitter -i {input} {params.out} -t 1 -c 1
+        fastqsplitter -i {input} {params.out_args} -t 1 -c 1
         """
 
+# ---- Helper for explicit per-sample scatter outputs in demultiplex_fastq_split. ----
+def get_sample_names():
+    return sorted(samples_unique["sample_name"].unique().tolist())
 
-rule split_R2:
-    input:
-        out("{experiment_name}/raw_reads/Undetermined_S0_R2_001.fastq.gz"),
-    output:
-        temp(
-            scatter.fastq_split(
-                out("{{experiment_name}}/raw_reads_split/R2_{scatteritem}.fastq.gz")
-            )
-        ),
-    threads: 5
-    resources:
-        mem_mb=1024 * 10,
-    benchmark:
-        out("benchmarks/{experiment_name}/split_R2.txt")
-    params:
-        out=lambda w: [
-            "-o " +
-            out(f"{w.experiment_name}/raw_reads_split/R2_{i}-of-")
-            + str(workflow._scatter["fastq_split"])
-            + ".fastq.gz"
-            for i in range(1, workflow._scatter["fastq_split"] + 1)
-        ],
-    conda:
-        "envs/sci-rocket.yaml",
-    message:
-        "Generating multiple evenly-sized R2 chunks ({wildcards.experiment_name})."
-    shell:
-        """
-        fastqsplitter -i {input} {params.out} -t 1 -c 1
-        """
 
-# ---- Demultiplex each splitted R1 and R2 file to generate sample-specific fastq.gz files. ----
-       
+# ---- Demultiplex each split R1 and R2 file and emit sample-specific fastq.gz files. ----
 rule demultiplex_fastq_split:
     input:
         R1=out("{experiment_name}/raw_reads_split/R1_{scatteritem}.fastq.gz"),
         R2=out("{experiment_name}/raw_reads_split/R2_{scatteritem}.fastq.gz"),
     output:
-        out_dir=temp(directory(out("{experiment_name}/demux_reads_scatter/{scatteritem}"))),
         discard_R1=temp(out("{experiment_name}/demux_reads_scatter/{scatteritem}/{experiment_name}_R1_discarded.fastq.gz")),
         discard_R2=temp(out("{experiment_name}/demux_reads_scatter/{scatteritem}/{experiment_name}_R2_discarded.fastq.gz")),
         discard_log=temp(out("{experiment_name}/demux_reads_scatter/{scatteritem}/log_{experiment_name}_discarded_reads.tsv.gz")),
+        qc=temp(out("{experiment_name}/demux_reads_scatter/{scatteritem}/{experiment_name}_qc.pickle")),
+        whitelist_p7=temp(out("{experiment_name}/demux_reads_scatter/{scatteritem}/{experiment_name}_whitelist_p7.txt")),
+        whitelist_p5=temp(out("{experiment_name}/demux_reads_scatter/{scatteritem}/{experiment_name}_whitelist_p5.txt")),
+        whitelist_ligation=temp(out("{experiment_name}/demux_reads_scatter/{scatteritem}/{experiment_name}_whitelist_ligation.txt")),
+        whitelist_rt=temp(out("{experiment_name}/demux_reads_scatter/{scatteritem}/{experiment_name}_whitelist_rt.txt")),
+        sample_R1=temp(expand(out("{{experiment_name}}/demux_reads_scatter/{{scatteritem}}/{sample_name}_R1.fastq.gz"), sample_name=get_sample_names())),
+        sample_R2=temp(expand(out("{{experiment_name}}/demux_reads_scatter/{{scatteritem}}/{sample_name}_R2.fastq.gz"), sample_name=get_sample_names())),
     log:
         out("logs/step2_demultiplexing_reads/demultiplex_fastq_split_{experiment_name}_{scatteritem}.log"),
     threads: 1
@@ -92,6 +65,7 @@ rule demultiplex_fastq_split:
     params:
         path_samples=config["path_samples"],
         path_barcodes=config["path_barcodes"],
+        path_out=out("{experiment_name}/demux_reads_scatter/{scatteritem}"),
     conda:
         "envs/sci-rocket.yaml",
     message:
@@ -103,13 +77,20 @@ rule demultiplex_fastq_split:
         --samples {params.path_samples} \
         --barcodes {params.path_barcodes} \
         --r1 {input.R1} --r2 {input.R2} \
-        --out {output.out_dir} &> {log}
+        --out {params.path_out} &> {log}
         """
 
 
 rule gather_demultiplexed_sequencing:
     input:
-        gather.fastq_split(out("{{experiment_name}}/demux_reads_scatter/{scatteritem}/")),
+        discard_R1=gather.fastq_split(out("{{experiment_name}}/demux_reads_scatter/{scatteritem}/{{experiment_name}}_R1_discarded.fastq.gz")),
+        discard_R2=gather.fastq_split(out("{{experiment_name}}/demux_reads_scatter/{scatteritem}/{{experiment_name}}_R2_discarded.fastq.gz")),
+        discard_log=gather.fastq_split(out("{{experiment_name}}/demux_reads_scatter/{scatteritem}/log_{{experiment_name}}_discarded_reads.tsv.gz")),
+        qc_pickles=gather.fastq_split(out("{{experiment_name}}/demux_reads_scatter/{scatteritem}/{{experiment_name}}_qc.pickle")),
+        whitelist_p7=gather.fastq_split(out("{{experiment_name}}/demux_reads_scatter/{scatteritem}/{{experiment_name}}_whitelist_p7.txt")),
+        whitelist_p5=gather.fastq_split(out("{{experiment_name}}/demux_reads_scatter/{scatteritem}/{{experiment_name}}_whitelist_p5.txt")),
+        whitelist_ligation=gather.fastq_split(out("{{experiment_name}}/demux_reads_scatter/{scatteritem}/{{experiment_name}}_whitelist_ligation.txt")),
+        whitelist_rt=gather.fastq_split(out("{{experiment_name}}/demux_reads_scatter/{scatteritem}/{{experiment_name}}_whitelist_rt.txt")),
     output:
         R1_discarded=out("{experiment_name}/demux_reads/{experiment_name}_R1_discarded.fastq.gz"),
         R2_discarded=out("{experiment_name}/demux_reads/{experiment_name}_R2_discarded.fastq.gz"),
@@ -138,20 +119,22 @@ rule gather_demultiplexed_sequencing:
         python {workflow.basedir}/rules/scripts/demultiplexing/demux_gather.py --path_demux_scatter {params.path_demux_scatter} --path_out {output.qc}
 
         # Combine the sequencing-specific R1/R2 discarded reads and logs.
-        find {params.path_demux_scatter} -maxdepth 2 -type f -name {wildcards.experiment_name}_R1_discarded.fastq.gz -print0 | xargs -0 cat > {output.R1_discarded}
-        find {params.path_demux_scatter} -maxdepth 2 -type f -name {wildcards.experiment_name}_R2_discarded.fastq.gz -print0 | xargs -0 cat > {output.R2_discarded}
-        find {params.path_demux_scatter} -maxdepth 2 -type f -name log_{wildcards.experiment_name}_discarded_reads.tsv.gz -print0 | xargs -0 cat > {output.discarded_log}
+        cat {input.discard_R1} > {output.R1_discarded}
+        cat {input.discard_R2} > {output.R2_discarded}
+        printf "read_name\tp5\tp7\tligation\trt\tumi\tsample_name\n" | gzip -c > {output.discarded_log}
+        cat {input.discard_log} >> {output.discarded_log}
 
         # Move the whitelist files.
-        find {params.path_demux_scatter} -maxdepth 2 -type f -name {wildcards.experiment_name}_whitelist_p7.txt -print0 | xargs -0 cat | sort -u > {output.whitelist_p7}
-        find {params.path_demux_scatter} -maxdepth 2 -type f -name {wildcards.experiment_name}_whitelist_p5.txt -print0 | xargs -0 cat | sort -u > {output.whitelist_p5}
-        find {params.path_demux_scatter} -maxdepth 2 -type f -name {wildcards.experiment_name}_whitelist_ligation.txt -print0 | xargs -0 cat | sort -u > {output.whitelist_ligation}
-        find {params.path_demux_scatter} -maxdepth 2 -type f -name {wildcards.experiment_name}_whitelist_rt.txt -print0 | xargs -0 cat | sort -u > {output.whitelist_rt}
+        cat {input.whitelist_p7} | sort -u > {output.whitelist_p7}
+        cat {input.whitelist_p5} | sort -u > {output.whitelist_p5}
+        cat {input.whitelist_ligation} | sort -u > {output.whitelist_ligation}
+        cat {input.whitelist_rt} | sort -u > {output.whitelist_rt}
         """
 
 rule gather_demultiplexed_samples:
     input:
-        gather.fastq_split(out("{{experiment_name}}/demux_reads_scatter/{scatteritem}/")),
+        R1_scatter=gather.fastq_split(out("{{experiment_name}}/demux_reads_scatter/{scatteritem}/{{sample_name}}_R1.fastq.gz")),
+        R2_scatter=gather.fastq_split(out("{{experiment_name}}/demux_reads_scatter/{scatteritem}/{{sample_name}}_R2.fastq.gz")),
     output:
         R1=out("{experiment_name}/demux_reads/{sample_name}_R1.fastq.gz"),
         R2=out("{experiment_name}/demux_reads/{sample_name}_R2.fastq.gz"),
@@ -160,13 +143,11 @@ rule gather_demultiplexed_samples:
         mem_mb=1024 * 10,
     benchmark:
         out("benchmarks/{experiment_name}/gather_demultiplexed_samples_{sample_name}.txt")
-    params:
-        path_demux_scatter=lambda w: out(f"{w.experiment_name}/demux_reads_scatter/")
     message:
-        "Combining the sample-specific fastq.fz files ({wildcards.experiment_name})."
+        "Combining the sample-specific fastq.gz files ({wildcards.experiment_name})."
     shell:
         """
         # Combine files.
-        find {params.path_demux_scatter} -maxdepth 2 -type f -name {wildcards.sample_name}_R1.fastq.gz -print0 | xargs -0 cat > {output.R1}
-        find {params.path_demux_scatter} -maxdepth 2 -type f -name {wildcards.sample_name}_R2.fastq.gz -print0 | xargs -0 cat > {output.R2}
+        cat {input.R1_scatter} > {output.R1}
+        cat {input.R2_scatter} > {output.R2}
         """


### PR DESCRIPTION
- fix bug where the scatter temp files were deleted before being merged into the final discarded_reads.tsv.gz
- also fix bug where discard tsv would have a duplicate header line for each scatter contribution
- refactor workflow to make input/output files more explicit and remove find calls from shell scripts in favour of specifying inputs and outputs directly
- refactor split_R1 and split_R2 into split_reads with wildcard over R1/R2 to reduce duplication
- add and extend demux tests