### PR TITLE
Extend hashing summary in dashboard

### DIFF
--- a/tests/integration/aviti/tests/test_consistency.py
+++ b/tests/integration/aviti/tests/test_consistency.py
@@ -35,6 +35,9 @@ def load_scidash_data(experiment: str) -> dict:
     "sample_success",
     "hashing",
     "hashing_summary",
+    "hashing_summary_filt",
+    "hashing_summary_bins",
+    "hashing_summary_bin_labels",
 ]
 )
 def test_output_consistent_between_experiments(experiment: str, field: str):

--- a/tests/integration/aviti/tests/test_sci_dash.py
+++ b/tests/integration/aviti/tests/test_sci_dash.py
@@ -45,16 +45,25 @@ def test_sci_dash_data():
 
     # Check hashing summary consistency against per-hash counts.
     assert "hashing_summary" in data
+    assert "hashing_summary_filt" in data
+    assert "hashing_summary_bins" in data
+    assert "hashing_summary_bin_labels" in data
     assert len(data["hashing_summary"]) == len(data["hashing"])
+    assert len(data["hashing_summary_filt"]) == len(data["hashing"])
     assert set(row["sample_name"] for row in data["hashing_summary"]) == set(data["hashing"].keys())
+    assert set(row["sample_name"] for row in data["hashing_summary_filt"]) == set(data["hashing"].keys())
     assert all("experiment_name" not in row for row in data["hashing_summary"])
+    assert all("experiment_name" not in row for row in data["hashing_summary_filt"])
 
     for row in data["hashing_summary"]:
         sample = row["sample_name"]
         sample_hash_total = sum(
             v["n_correct"] + v["n_corrected"] + v["n_correct_upstream"] for v in data["hashing"][sample].values()
         )
-        assert row["count_total"] == sample_hash_total
+        assert row["hash_count_total"] == sample_hash_total
+
+    expected_bin_rows = len(data["hashing"]) * len(data["hashing_summary_bin_labels"])
+    assert len(data["hashing_summary_bins"]) == expected_bin_rows
 
     assert data["rt_barcode_counts"]["P01"][0] == {'row': 'D', 'col': '9', 'frequency': 1112}
     assert data["rt_barcode_counts"]["P01"][1] == {'row': 'B', 'col': '8', 'frequency': 830}

--- a/tests/integration/bcl/tests/test_consistency.py
+++ b/tests/integration/bcl/tests/test_consistency.py
@@ -35,6 +35,9 @@ def load_scidash_data(experiment: str) -> dict:
     "sample_success",
     "hashing",
     "hashing_summary",
+    "hashing_summary_filt",
+    "hashing_summary_bins",
+    "hashing_summary_bin_labels",
 ]
 )
 def test_output_consistent_between_experiments(experiment: str, field: str):

--- a/tests/integration/bcl/tests/test_sci_dash.py
+++ b/tests/integration/bcl/tests/test_sci_dash.py
@@ -31,15 +31,24 @@ def test_sci_dash_data():
 
     # Check hashing summary consistency against per-hash counts.
     assert "hashing_summary" in data
+    assert "hashing_summary_filt" in data
+    assert "hashing_summary_bins" in data
+    assert "hashing_summary_bin_labels" in data
     assert len(data["hashing_summary"]) == len(data["hashing"])
+    assert len(data["hashing_summary_filt"]) == len(data["hashing"])
     assert set(row["sample_name"] for row in data["hashing_summary"]) == set(data["hashing"].keys())
+    assert set(row["sample_name"] for row in data["hashing_summary_filt"]) == set(data["hashing"].keys())
     assert all("experiment_name" not in row for row in data["hashing_summary"])
+    assert all("experiment_name" not in row for row in data["hashing_summary_filt"])
 
     for row in data["hashing_summary"]:
         sample = row["sample_name"]
         sample_hash_total = sum(
             v["n_correct"] + v["n_corrected"] + v["n_correct_upstream"] for v in data["hashing"][sample].values()
         )
-        assert row["count_total"] == sample_hash_total
+        assert row["hash_count_total"] == sample_hash_total
+
+    expected_bin_rows = len(data["hashing"]) * len(data["hashing_summary_bin_labels"])
+    assert len(data["hashing_summary_bins"]) == expected_bin_rows
 
     assert data["rt_barcode_counts"]["P01"][0] == {'row': 'B', 'col': '1', 'frequency': 2048}

--- a/tests/unit/demultiplexing/test_demux_dash.py
+++ b/tests/unit/demultiplexing/test_demux_dash.py
@@ -2,7 +2,10 @@ import pytest
 import pandas as pd
 
 from workflow.rules.scripts.demultiplexing.demux_dash import (
+    HASH_COUNT_BIN_LABELS,
+    calculate_hashing_bin_summary,
     calculate_hashing_summary,
+    calculate_hashing_summary_filtered,
     parse_summary_metrics,
     resolve_solo_feature_paths,
 )
@@ -12,16 +15,16 @@ def test_calculate_hashing_summary_matches_expected_aggregation():
     df_hashing = pd.DataFrame(
         [
             # sample_1, cell_a: ratio = 10 / 2 = 5
-            {"experiment_name": "exp1", "sample_name": "sample_1", "hashing_name": "H1", "cell_barcode": "cell_a", "count": 10},
-            {"experiment_name": "exp1", "sample_name": "sample_1", "hashing_name": "H2", "cell_barcode": "cell_a", "count": 2},
-            # sample_1, cell_b: only one hash, ratio = NA
-            {"experiment_name": "exp1", "sample_name": "sample_1", "hashing_name": "H3", "cell_barcode": "cell_b", "count": 8},
+            {"experiment_name": "exp1", "sample_name": "sample_1", "hashing_name": "H1", "cell_barcode": "cell_a", "count": 10, "n_umi": 6},
+            {"experiment_name": "exp1", "sample_name": "sample_1", "hashing_name": "H2", "cell_barcode": "cell_a", "count": 2, "n_umi": 2},
+            # sample_1, cell_b: only one hash, ratio = 8 / 1 = 8 (pseudocount)
+            {"experiment_name": "exp1", "sample_name": "sample_1", "hashing_name": "H3", "cell_barcode": "cell_b", "count": 8, "n_umi": 4},
             # sample_1, cell_c: ratio = 9 / 3 = 3
-            {"experiment_name": "exp1", "sample_name": "sample_1", "hashing_name": "H1", "cell_barcode": "cell_c", "count": 9},
-            {"experiment_name": "exp1", "sample_name": "sample_1", "hashing_name": "H2", "cell_barcode": "cell_c", "count": 3},
+            {"experiment_name": "exp1", "sample_name": "sample_1", "hashing_name": "H1", "cell_barcode": "cell_c", "count": 9, "n_umi": 5},
+            {"experiment_name": "exp1", "sample_name": "sample_1", "hashing_name": "H2", "cell_barcode": "cell_c", "count": 3, "n_umi": 1},
             # sample_2 reuses cell_a barcode to confirm grouping is sample-aware.
-            {"experiment_name": "exp1", "sample_name": "sample_2", "hashing_name": "H1", "cell_barcode": "cell_a", "count": 6},
-            {"experiment_name": "exp1", "sample_name": "sample_2", "hashing_name": "H2", "cell_barcode": "cell_a", "count": 3},
+            {"experiment_name": "exp1", "sample_name": "sample_2", "hashing_name": "H1", "cell_barcode": "cell_a", "count": 6, "n_umi": 3},
+            {"experiment_name": "exp1", "sample_name": "sample_2", "hashing_name": "H2", "cell_barcode": "cell_a", "count": 3, "n_umi": 2},
         ]
     )
 
@@ -31,27 +34,31 @@ def test_calculate_hashing_summary_matches_expected_aggregation():
     assert set(summary_by_sample) == {"sample_1", "sample_2"}
 
     sample_1 = summary_by_sample["sample_1"]
-    assert sample_1["count_total"] == 32
-    assert sample_1["cells_passing"] == 2
-    assert sample_1["fraction_passing"] == pytest.approx(2 / 3)
-    assert sample_1["mean_count"] == pytest.approx((12 + 8 + 12) / 3)
-    assert sample_1["median_ratio"] == pytest.approx(4.0)
-    assert sample_1["mean_ratio"] == pytest.approx(4.0)
+    assert sample_1["hash_count_total"] == 32
+    assert sample_1["hash_umi_total"] == 15
+    assert sample_1["cells_passing"] == 3
+    assert sample_1["fraction_passing"] == pytest.approx(1.0)
+    assert sample_1["mean_hash_count"] == pytest.approx((12 + 8 + 12) / 3)
+    assert sample_1["median_hash_ratio"] == pytest.approx(5.0)
+    assert sample_1["mean_hash_ratio"] == pytest.approx((5 + 8 + 3) / 3)
+    assert sample_1["total_cells"] == 3
 
     sample_2 = summary_by_sample["sample_2"]
-    assert sample_2["count_total"] == 9
+    assert sample_2["hash_count_total"] == 9
+    assert sample_2["hash_umi_total"] == 3
     assert sample_2["cells_passing"] == 0
     assert sample_2["fraction_passing"] == pytest.approx(0.0)
-    assert sample_2["mean_count"] == pytest.approx(9.0)
-    assert sample_2["median_ratio"] == pytest.approx(2.0)
-    assert sample_2["mean_ratio"] == pytest.approx(2.0)
+    assert sample_2["mean_hash_count"] == pytest.approx(9.0)
+    assert sample_2["median_hash_ratio"] == pytest.approx(2.0)
+    assert sample_2["mean_hash_ratio"] == pytest.approx(2.0)
+    assert sample_2["total_cells"] == 1
 
 
 def test_calculate_hashing_summary_includes_samples_without_cell_rows():
     df_hashing = pd.DataFrame(
         [
-            {"sample_name": "sample_with_reads", "hashing_name": "H1", "cell_barcode": "cell_a", "count": 4},
-            {"sample_name": "sample_with_reads", "hashing_name": "H2", "cell_barcode": "cell_a", "count": 2},
+            {"sample_name": "sample_with_reads", "hashing_name": "H1", "cell_barcode": "cell_a", "count": 4, "n_umi": 2},
+            {"sample_name": "sample_with_reads", "hashing_name": "H2", "cell_barcode": "cell_a", "count": 2, "n_umi": 1},
         ]
     )
 
@@ -61,12 +68,78 @@ def test_calculate_hashing_summary_includes_samples_without_cell_rows():
     assert set(summary_by_sample) == {"sample_with_reads", "sample_empty"}
 
     sample_empty = summary_by_sample["sample_empty"]
-    assert sample_empty["count_total"] == 0
+    assert sample_empty["hash_count_total"] == 0
+    assert sample_empty["hash_umi_total"] == 0
     assert sample_empty["cells_passing"] == 0
     assert sample_empty["fraction_passing"] is None
-    assert sample_empty["mean_count"] is None
-    assert sample_empty["median_ratio"] is None
-    assert sample_empty["mean_ratio"] is None
+    assert sample_empty["mean_hash_count"] is None
+    assert sample_empty["median_hash_ratio"] is None
+    assert sample_empty["mean_hash_ratio"] is None
+    assert sample_empty["total_cells"] == 0
+
+
+def test_calculate_hashing_summary_filtered_uses_hash_umi_total_threshold():
+    df_hashing = pd.DataFrame(
+        [
+            # Filtered out (top n_umi = 4).
+            {"sample_name": "sample_1", "hashing_name": "H1", "cell_barcode": "cell_a", "count": 10, "n_umi": 4},
+            {"sample_name": "sample_1", "hashing_name": "H2", "cell_barcode": "cell_a", "count": 1, "n_umi": 1},
+            # Kept (top n_umi = 5).
+            {"sample_name": "sample_1", "hashing_name": "H1", "cell_barcode": "cell_b", "count": 6, "n_umi": 5},
+            {"sample_name": "sample_1", "hashing_name": "H2", "cell_barcode": "cell_b", "count": 3, "n_umi": 2},
+        ]
+    )
+
+    summary = calculate_hashing_summary_filtered(df_hashing, sample_names=["sample_1"])
+    sample_1 = summary[0]
+
+    assert sample_1["total_cells"] == 1
+    assert sample_1["hash_count_total"] == 9
+    assert sample_1["hash_umi_total"] == 5
+    assert sample_1["mean_hash_count"] == pytest.approx(9.0)
+    assert sample_1["cells_passing"] == 0
+    assert sample_1["fraction_passing"] == pytest.approx(0.0)
+
+
+def test_calculate_hashing_bin_summary_returns_all_bins_with_labels():
+    df_hashing = pd.DataFrame(
+        [
+            # sample_1, cell_a -> bin 1-10, passing
+            {"sample_name": "sample_1", "hashing_name": "H1", "cell_barcode": "cell_a", "count": 7, "n_umi": 6},
+            {"sample_name": "sample_1", "hashing_name": "H2", "cell_barcode": "cell_a", "count": 1, "n_umi": 1},
+            # sample_1, cell_b -> bin 21-30, not passing
+            {"sample_name": "sample_1", "hashing_name": "H1", "cell_barcode": "cell_b", "count": 15, "n_umi": 5},
+            {"sample_name": "sample_1", "hashing_name": "H2", "cell_barcode": "cell_b", "count": 10, "n_umi": 2},
+            # sample_2, cell_c -> bin 100+, passing
+            {"sample_name": "sample_2", "hashing_name": "H1", "cell_barcode": "cell_c", "count": 120, "n_umi": 8},
+            {"sample_name": "sample_2", "hashing_name": "H2", "cell_barcode": "cell_c", "count": 10, "n_umi": 3},
+        ]
+    )
+
+    rows = calculate_hashing_bin_summary(df_hashing, sample_names=["sample_1", "sample_2"])
+    assert len(rows) == 2 * len(HASH_COUNT_BIN_LABELS)
+
+    lookup = {(row["sample_name"], row["count_bin"]): row for row in rows}
+
+    sample1_1_10 = lookup[("sample_1", "1-10")]
+    assert sample1_1_10["n_cells"] == 1
+    assert sample1_1_10["fraction_passing"] == pytest.approx(1.0)
+    assert sample1_1_10["label"] == "100% (n=1)"
+
+    sample1_21_30 = lookup[("sample_1", "21-30")]
+    assert sample1_21_30["n_cells"] == 1
+    assert sample1_21_30["fraction_passing"] == pytest.approx(0.0)
+    assert sample1_21_30["label"] == "0% (n=1)"
+
+    sample1_100_plus = lookup[("sample_1", "100+")]
+    assert sample1_100_plus["n_cells"] == 0
+    assert sample1_100_plus["fraction_passing"] is None
+    assert sample1_100_plus["label"] == "·"
+
+    sample2_100_plus = lookup[("sample_2", "100+")]
+    assert sample2_100_plus["n_cells"] == 1
+    assert sample2_100_plus["fraction_passing"] == pytest.approx(1.0)
+    assert sample2_100_plus["label"] == "100% (n=1)"
 
 
 def test_parse_summary_metrics_supports_gene_feature_labels(tmp_path):

--- a/workflow/rules/scripts/demultiplexing/demux_dash.py
+++ b/workflow/rules/scripts/demultiplexing/demux_dash.py
@@ -6,6 +6,11 @@ import pickle
 import sys
 import pathlib
 
+HASH_RATIO_PASSING_THRESHOLD = 3.0
+HASH_UMI_FILTER_THRESHOLD = 5
+HASH_COUNT_BIN_LABELS = [f"{start}-{start + 9}" for start in range(1, 100, 10)] + ["100+"]
+HASH_COUNT_BIN_BREAKS = list(range(0, 101, 10)) + [float("inf")]
+
 
 def parse_float(value):
     return float(value.strip())
@@ -126,41 +131,56 @@ def calculate_hashing_cell_dominance_rows(df_hashing: pd.DataFrame) -> list[dict
     rows = []
     for (sample_name, cell_barcode), group in df_hashing.groupby(["sample_name", "cell_barcode"], sort=False):
         ranked = group.sort_values(by=["count", "hashing_name"], ascending=[False, True]).reset_index(drop=True)
-        count_top = int(ranked.loc[0, "count"])
-        count_total = int(ranked["count"].sum())
+        hash_count_top = int(ranked.loc[0, "count"])
+        hash_count_total = int(ranked["count"].sum())
+        hash_umi_total = ranked.loc[0, "n_umi"] if "n_umi" in ranked.columns else hash_count_top
+        hash_umi_total = int(hash_umi_total) if pd.notna(hash_umi_total) else 0
         top_hash = str(ranked.loc[0, "hashing_name"])
 
-        count_second = None
-        ratio = None
+        hash_count_second = None
         if len(ranked) > 1:
-            count_second = int(ranked.loc[1, "count"])
-            if count_second > 0:
-                ratio = float(count_top / count_second)
+            hash_count_second = int(ranked.loc[1, "count"])
+
+        # Use a pseudocount of 1 when no second hash exists for this cell.
+        if hash_count_second is None:
+            hash_enrichment_ratio = float(hash_count_top)
+        elif hash_count_second == 0:
+            hash_enrichment_ratio = float("inf")
+        else:
+            hash_enrichment_ratio = float(hash_count_top / hash_count_second)
 
         rows.append(
             {
                 "sample_name": str(sample_name),
                 "cell_barcode": str(cell_barcode),
                 "top_hash": top_hash,
-                "count_top": count_top,
-                "count_second": count_second,
-                "count_total": count_total,
-                "ratio": ratio,
+                "hash_count_top": hash_count_top,
+                "hash_count_second": hash_count_second,
+                "hash_count_total": hash_count_total,
+                "hash_umi_total": hash_umi_total,
+                "hash_enrichment_ratio": hash_enrichment_ratio,
             }
         )
 
     return rows
 
 
-def calculate_hashing_summary(df_hashing: pd.DataFrame, sample_names: list[str] | None = None) -> list[dict]:
-    """
-    Reproduce the sample-level hashing summary statistics from hashing_metrics.tsv.
-    """
-
+def _get_hashing_cell_dominance_df(df_hashing: pd.DataFrame) -> pd.DataFrame:
     rows = calculate_hashing_cell_dominance_rows(df_hashing)
-    df_cells = pd.DataFrame(rows, columns=["sample_name", "cell_barcode", "top_hash", "count_top", "count_second", "count_total", "ratio"])
+    columns = [
+        "sample_name",
+        "cell_barcode",
+        "top_hash",
+        "hash_count_top",
+        "hash_count_second",
+        "hash_count_total",
+        "hash_umi_total",
+        "hash_enrichment_ratio",
+    ]
+    return pd.DataFrame(rows, columns=columns)
 
-    # Summarize at experiment/sample level.
+
+def _summarize_hashing_cells(df_cells: pd.DataFrame, sample_names: list[str] | None = None) -> list[dict]:
     summary = []
     grouped = {sample_name: group for sample_name, group in df_cells.groupby("sample_name", sort=False)}
     ordered_sample_names = sample_names if sample_names is not None else list(grouped.keys())
@@ -171,29 +191,128 @@ def calculate_hashing_summary(df_hashing: pd.DataFrame, sample_names: list[str] 
         else:
             group = df_cells.iloc[0:0]
 
-        ratios = group["ratio"].dropna()
-        cells_passing = int((group["ratio"] >= 3).fillna(False).sum())
-        n_cells = int(len(group))
+        ratios = group["hash_enrichment_ratio"].dropna()
+        cells_passing = int((group["hash_enrichment_ratio"] >= HASH_RATIO_PASSING_THRESHOLD).fillna(False).sum())
+        total_cells = int(len(group))
 
-        mean_count = float(group["count_total"].mean()) if n_cells else None
-        count_total = int(group["count_total"].sum()) if n_cells else 0
-        median_ratio = float(ratios.median()) if len(ratios) else None
-        mean_ratio = float(ratios.mean()) if len(ratios) else None
-        fraction_passing = float(cells_passing / n_cells) if n_cells else None
+        mean_hash_count = float(group["hash_count_total"].mean()) if total_cells else None
+        hash_count_total = int(group["hash_count_total"].sum()) if total_cells else 0
+        hash_umi_total = int(group["hash_umi_total"].sum()) if total_cells else 0
+        median_hash_ratio = float(ratios.median()) if len(ratios) else None
+        mean_hash_ratio = float(ratios.mean()) if len(ratios) else None
+        fraction_passing = float(cells_passing / total_cells) if total_cells else None
 
         summary.append(
             {
                 "sample_name": str(sample_name),
-                "mean_count": mean_count,
-                "count_total": count_total,
-                "median_ratio": median_ratio,
-                "mean_ratio": mean_ratio,
+                "mean_hash_count": mean_hash_count,
+                "hash_count_total": hash_count_total,
+                "hash_umi_total": hash_umi_total,
+                "median_hash_ratio": median_hash_ratio,
+                "mean_hash_ratio": mean_hash_ratio,
+                "total_cells": total_cells,
                 "cells_passing": cells_passing,
                 "fraction_passing": fraction_passing,
             }
         )
 
     return summary
+
+
+def _filter_hashing_cells(df_cells: pd.DataFrame, min_hash_umi_total: int) -> pd.DataFrame:
+    if df_cells.empty:
+        return df_cells.copy()
+    return df_cells[df_cells["hash_umi_total"] >= min_hash_umi_total].copy()
+
+
+def calculate_hashing_summary(
+    df_hashing: pd.DataFrame,
+    sample_names: list[str] | None = None,
+) -> list[dict]:
+    """
+    Summarize cell-level hashing dominance statistics per sample.
+    """
+    df_cells = _get_hashing_cell_dominance_df(df_hashing)
+    return _summarize_hashing_cells(df_cells, sample_names=sample_names)
+
+
+def calculate_hashing_summary_filtered(
+    df_hashing: pd.DataFrame,
+    sample_names: list[str] | None = None,
+    min_hash_umi_total: int = HASH_UMI_FILTER_THRESHOLD,
+) -> list[dict]:
+    """
+    Summarize cell-level hashing dominance statistics per sample after
+    filtering cells on hash_umi_total.
+    """
+    df_cells = _get_hashing_cell_dominance_df(df_hashing)
+    df_cells_filt = _filter_hashing_cells(df_cells, min_hash_umi_total=min_hash_umi_total)
+    return _summarize_hashing_cells(df_cells_filt, sample_names=sample_names)
+
+
+def calculate_hashing_bin_summary(
+    df_hashing: pd.DataFrame,
+    sample_names: list[str] | None = None,
+    min_hash_umi_total: int = HASH_UMI_FILTER_THRESHOLD,
+) -> list[dict]:
+    """
+    Build sample/count-bin rows with passing fraction and n_cells.
+    """
+    df_cells = _get_hashing_cell_dominance_df(df_hashing)
+    df_cells_filt = _filter_hashing_cells(df_cells, min_hash_umi_total=min_hash_umi_total)
+
+    if sample_names is None:
+        sample_names = list(dict.fromkeys(df_cells_filt["sample_name"].tolist()))
+
+    if df_cells_filt.empty:
+        by_sample_and_bin = {}
+    else:
+        df_cells_filt["count_bin"] = pd.cut(
+            df_cells_filt["hash_count_total"],
+            bins=HASH_COUNT_BIN_BREAKS,
+            labels=HASH_COUNT_BIN_LABELS,
+            include_lowest=True,
+        )
+
+        by_sample_and_bin = {}
+        for (sample_name, count_bin), group in df_cells_filt.groupby(["sample_name", "count_bin"], sort=False, observed=True):
+            n_cells = int(len(group))
+            fraction_passing = float((group["hash_enrichment_ratio"] >= HASH_RATIO_PASSING_THRESHOLD).mean()) if n_cells else None
+            by_sample_and_bin[(str(sample_name), str(count_bin))] = {
+                "fraction_passing": fraction_passing,
+                "n_cells": n_cells,
+            }
+
+    rows = []
+    for sample_name in sample_names:
+        sample_name = str(sample_name)
+        for count_bin in HASH_COUNT_BIN_LABELS:
+            cell = by_sample_and_bin.get((sample_name, count_bin))
+            if cell is None:
+                rows.append(
+                    {
+                        "sample_name": sample_name,
+                        "count_bin": count_bin,
+                        "fraction_passing": None,
+                        "n_cells": 0,
+                        "label": "·",
+                    }
+                )
+                continue
+
+            fraction_passing = cell["fraction_passing"]
+            n_cells = cell["n_cells"]
+            rows.append(
+                {
+                    "sample_name": sample_name,
+                    "count_bin": count_bin,
+                    "fraction_passing": fraction_passing,
+                    "n_cells": n_cells,
+                    "label": f"{fraction_passing * 100:.0f}% (n={n_cells})" if fraction_passing is not None else "·",
+                }
+            )
+
+    return rows
 
 
 def write_cell_hashing_table(qc, out):
@@ -208,7 +327,9 @@ def write_cell_hashing_table(qc, out):
 
     Returns:
         (dict): Dictionary of the hashing metrics for the dashboard hashing table.
-        (list[dict]): Summary statistics derived from the cell-level hashing metrics.
+        (list[dict]): Summary statistics derived from all cells.
+        (list[dict]): Summary statistics with low hash_umi_total cells removed.
+        (list[dict]): Per-bin sample summaries on filtered cells.
     """
 
     # Create a list of dictionaries.
@@ -261,6 +382,8 @@ def write_cell_hashing_table(qc, out):
 
     # Build sample-level summary statistics used in an extra dashboard table.
     hashing_summary = calculate_hashing_summary(df_hashing, sample_names=list(qc["hashing"].keys()))
+    hashing_summary_filt = calculate_hashing_summary_filtered(df_hashing, sample_names=list(qc["hashing"].keys()))
+    hashing_summary_bins = calculate_hashing_bin_summary(df_hashing, sample_names=list(qc["hashing"].keys()))
 
     # Transform into a dictionary for sci-dashboard.
     # Initialize the dictionary of sample_name and underlying hashing_name also a dictionary.
@@ -272,7 +395,7 @@ def write_cell_hashing_table(qc, out):
             dict_hashing[sample_name][hashing_name]["n_corrected"] = qc["hashing"][sample_name][hashing_name]["n_corrected"]
             dict_hashing[sample_name][hashing_name]["n_correct_upstream"] = qc["hashing"][sample_name][hashing_name]["n_correct_upstream"]
 
-    return dict_hashing, hashing_summary
+    return dict_hashing, hashing_summary, hashing_summary_filt, hashing_summary_bins
 
 
 def combine_logs(path_pickle, path_star, path_hashing, path_benchmarks):
@@ -380,12 +503,18 @@ def combine_logs(path_pickle, path_star, path_hashing, path_benchmarks):
 
     # region Write / import hashing statistics. --------------------------------------------------------------------------
     if "hashing" in qc:
-        dict_hashing, hashing_summary = write_cell_hashing_table(qc, path_hashing)
+        dict_hashing, hashing_summary, hashing_summary_filt, hashing_summary_bins = write_cell_hashing_table(qc, path_hashing)
         qc_json["hashing"] = dict_hashing
         qc_json["hashing_summary"] = hashing_summary
+        qc_json["hashing_summary_filt"] = hashing_summary_filt
+        qc_json["hashing_summary_bins"] = hashing_summary_bins
+        qc_json["hashing_summary_bin_labels"] = HASH_COUNT_BIN_LABELS
     else:
         qc_json["hashing"] = {}
         qc_json["hashing_summary"] = []
+        qc_json["hashing_summary_filt"] = []
+        qc_json["hashing_summary_bins"] = []
+        qc_json["hashing_summary_bin_labels"] = HASH_COUNT_BIN_LABELS
     # endregion ----------------------------------------------------------------------------------------------------------
 
     qc_json["benchmarks"] = get_benchmarks(path_benchmarks)

--- a/workflow/scirocket-dash/index.html
+++ b/workflow/scirocket-dash/index.html
@@ -330,7 +330,7 @@
                       <!--Tab: Hashing-->
                       <div class="tab-pane" id="tabs-hashing">
                         <div class="container">
-                          <h4>Hashing summary statistics</h4>
+                          <h4>Hashing summary statistics (all cells)</h4>
                           <div class="row">
                             <div class="card">
                               <div class="card-body">
@@ -338,6 +338,22 @@
                                   <table class="table" id="sample-hashing-summary-table">
                                   </table>
                                 </div>
+                              </div>
+                            </div>
+                          </div>
+                          <br />
+                          <h4>Hashing summary statistics (filtered: hash UMI >= 5)</h4>
+                          <div class="row">
+                            <div class="card">
+                              <div class="card-body">
+                                <div class="subheader">Table: sample-level filtered summary</div>
+                                <div class="table-responsive">
+                                  <table class="table" id="sample-hashing-summary-filt-table">
+                                  </table>
+                                </div>
+                                <br />
+                                <div class="subheader">Heatmap: fraction passing (ratio >= 3, filtered: hash UMI >= 5)</div>
+                                <div class="chart-lg" id="chart-hashing-bins-heatmap"></div>
                               </div>
                             </div>
                           </div>
@@ -486,6 +502,9 @@
     <!-- Import chart.js from CDN -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@3.0.0/dist/chartjs-chart-matrix.min.js"></script>
+
+    <!-- Import Plotly for standard heatmap rendering -->
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
 
     <!-- Import anychart from CDN -->
     <script src="https://cdn.amcharts.com/lib/5/index.js"></script>

--- a/workflow/scirocket-dash/js/sci_dash.js
+++ b/workflow/scirocket-dash/js/sci_dash.js
@@ -674,8 +674,47 @@ document.addEventListener("DOMContentLoaded", function () {
 // Table - Hashing summary.
 //--------------------------------------------
 
-function generate_hashing_summary_table(summaryRows) {
-  const table = document.getElementById("sample-hashing-summary-table");
+function insertFractionPassingCell(row, fractionPassing) {
+  const fractionCell = row.insertCell(-1);
+  if (fractionPassing == null) {
+    fractionCell.innerHTML = "NA";
+    return;
+  }
+
+  const fractionPassingPercent = Math.round(Number(fractionPassing) * 100);
+  let fractionPassingTextClass = "";
+  let fractionPassingBarClass = "";
+  if (fractionPassingPercent < 20) {
+    fractionPassingTextClass = "text-red";
+    fractionPassingBarClass = "bg-red";
+  } else if (fractionPassingPercent < 40) {
+    fractionPassingTextClass = "text-yellow";
+    fractionPassingBarClass = "bg-yellow";
+  }
+
+  const progress = createElement("div", "row align-items-center");
+  const col1 = createElement("div", `col-12 col-lg-auto ${fractionPassingTextClass}`, `${fractionPassingPercent}%`);
+  const col2 = createElement("div", "col");
+  const progress_bar = createElement("div", "progress");
+  progress_bar.style.width = "3rem";
+  progress_bar.style.height = "0.55rem";
+  const progress_bar_inner = createElement("div", `progress-bar ${fractionPassingBarClass}`);
+  progress_bar_inner.style.width = `${fractionPassingPercent}%`;
+  progress_bar_inner.setAttribute("role", "progressbar");
+  progress_bar_inner.setAttribute("aria-valuenow", fractionPassingPercent);
+  progress_bar_inner.setAttribute("aria-valuemin", "0");
+  progress_bar_inner.setAttribute("aria-valuemax", "100");
+  const span = createElement("span", "visually-hidden", `${fractionPassingPercent}%`);
+  progress_bar_inner.appendChild(span);
+  progress_bar.appendChild(progress_bar_inner);
+  col2.appendChild(progress_bar);
+  progress.appendChild(col1);
+  progress.appendChild(col2);
+  fractionCell.appendChild(progress);
+}
+
+function generate_hashing_summary_table(tableId, summaryRows) {
+  const table = document.getElementById(tableId);
   if (!table) return;
 
   table.className = "table card-table table-vcenter text-nowrap datatable tablesorter";
@@ -683,10 +722,12 @@ function generate_hashing_summary_table(summaryRows) {
       <thead>
         <tr>
           <th>Sample</th>
-          <th>Mean count</th>
-          <th>Count total</th>
+          <th>Mean hash count</th>
+          <th>Hash count total</th>
+          <th>Hash UMI total</th>
           <th>Median ratio</th>
           <th>Mean ratio</th>
+          <th>Total cells</th>
           <th>Cells passing<br><sub>(ratio >= 3)</sub></th>
           <th>Fraction passing</th>
         </tr>
@@ -695,51 +736,124 @@ function generate_hashing_summary_table(summaryRows) {
       </tbody>`;
 
   const tbody = table.querySelector("tbody");
+  const formatRatioValue = (value) => {
+    if (value == null) return "NA";
+    if (typeof value === "number" && !Number.isFinite(value)) {
+      return value > 0 ? "Inf" : "-Inf";
+    }
+    return roundToOne(value);
+  };
 
   for (const rowData of summaryRows) {
+    const meanHashCount = rowData.mean_hash_count;
+    const hashCountTotal = rowData.hash_count_total;
+    const hashUmiTotal = rowData.hash_umi_total;
+    const medianHashRatio = rowData.median_hash_ratio;
+    const meanHashRatio = rowData.mean_hash_ratio;
+    const totalCells = rowData.total_cells;
+
     const row = tbody.insertRow(-1);
     row.insertCell(0).innerHTML = rowData.sample_name ?? "";
-    row.insertCell(1).innerHTML = rowData.mean_count == null ? "NA" : roundToOne(rowData.mean_count);
-    row.insertCell(2).innerHTML = rowData.count_total == null ? "NA" : Intl.NumberFormat("en-US").format(rowData.count_total);
-    row.insertCell(3).innerHTML = rowData.median_ratio == null ? "NA" : roundToOne(rowData.median_ratio);
-    row.insertCell(4).innerHTML = rowData.mean_ratio == null ? "NA" : roundToOne(rowData.mean_ratio);
-    row.insertCell(5).innerHTML = rowData.cells_passing == null ? "NA" : Intl.NumberFormat("en-US").format(rowData.cells_passing);
-    const fractionCell = row.insertCell(6);
-    if (rowData.fraction_passing == null) {
-      fractionCell.innerHTML = "NA";
-    } else {
-      const fractionPassingPercent = Math.round(Number(rowData.fraction_passing) * 100);
-      let fractionPassingTextClass = "";
-      let fractionPassingBarClass = "";
-      if (fractionPassingPercent < 20) {
-        fractionPassingTextClass = "text-red";
-        fractionPassingBarClass = "bg-red";
-      } else if (fractionPassingPercent < 40) {
-        fractionPassingTextClass = "text-yellow";
-        fractionPassingBarClass = "bg-yellow";
-      }
+    row.insertCell(1).innerHTML = meanHashCount == null ? "NA" : roundToOne(meanHashCount);
+    row.insertCell(2).innerHTML = hashCountTotal == null ? "NA" : Intl.NumberFormat("en-US").format(hashCountTotal);
+    row.insertCell(3).innerHTML = hashUmiTotal == null ? "NA" : Intl.NumberFormat("en-US").format(hashUmiTotal);
+    row.insertCell(4).innerHTML = formatRatioValue(medianHashRatio);
+    row.insertCell(5).innerHTML = formatRatioValue(meanHashRatio);
+    row.insertCell(6).innerHTML = totalCells == null ? "NA" : Intl.NumberFormat("en-US").format(totalCells);
+    row.insertCell(7).innerHTML = rowData.cells_passing == null ? "NA" : Intl.NumberFormat("en-US").format(rowData.cells_passing);
+    insertFractionPassingCell(row, rowData.fraction_passing);
+  }
+}
 
-      const progress = createElement("div", "row align-items-center");
-      const col1 = createElement("div", `col-12 col-lg-auto ${fractionPassingTextClass}`, `${fractionPassingPercent}%`);
-      const col2 = createElement("div", "col");
-      const progress_bar = createElement("div", "progress");
-      progress_bar.style.width = "3rem";
-      progress_bar.style.height = "0.55rem";
-      const progress_bar_inner = createElement("div", `progress-bar ${fractionPassingBarClass}`);
-      progress_bar_inner.style.width = `${fractionPassingPercent}%`;
-      progress_bar_inner.setAttribute("role", "progressbar");
-      progress_bar_inner.setAttribute("aria-valuenow", fractionPassingPercent);
-      progress_bar_inner.setAttribute("aria-valuemin", "0");
-      progress_bar_inner.setAttribute("aria-valuemax", "100");
-      const span = createElement("span", "visually-hidden", `${fractionPassingPercent}%`);
-      progress_bar_inner.appendChild(span);
-      progress_bar.appendChild(progress_bar_inner);
-      col2.appendChild(progress_bar);
-      progress.appendChild(col1);
-      progress.appendChild(col2);
-      fractionCell.appendChild(progress);
+function generate_hashing_bins_heatmap(binRows, binLabels) {
+  const container = document.getElementById("chart-hashing-bins-heatmap");
+  if (!container) return;
+
+  if (typeof Plotly === "undefined") {
+    container.innerHTML = "<div style='text-align:center'><b>Heatmap library unavailable</b></div>";
+    return;
+  }
+
+  const xLabels = Array.isArray(binLabels) && binLabels.length > 0
+    ? binLabels
+    : [...new Set((binRows || []).map((row) => row.count_bin))];
+  const yLabels = [...new Set((binRows || []).map((row) => row.sample_name))];
+
+  if (xLabels.length === 0 || yLabels.length === 0) {
+    container.innerHTML = "<div style='text-align:center'><b>No bin data available</b></div>";
+    return;
+  }
+
+  const xIndexByLabel = Object.fromEntries(xLabels.map((label, idx) => [label, idx]));
+  const yIndexByLabel = Object.fromEntries(yLabels.map((label, idx) => [label, idx]));
+  const zMatrix = yLabels.map(() => xLabels.map(() => null));
+  const nCellMatrix = yLabels.map(() => xLabels.map(() => 0));
+
+  for (const row of (binRows || [])) {
+    if (!row || !(row.count_bin in xIndexByLabel) || !(row.sample_name in yIndexByLabel)) continue;
+    const xIdx = xIndexByLabel[row.count_bin];
+    const yIdx = yIndexByLabel[row.sample_name];
+    nCellMatrix[yIdx][xIdx] = Number(row.n_cells ?? 0);
+
+    if (row.n_cells > 0 && row.fraction_passing != null) {
+      zMatrix[yIdx][xIdx] = Number(row.fraction_passing) * 100;
     }
   }
+
+  const hasData = zMatrix.some((row) => row.some((value) => value != null && Number.isFinite(value)));
+  if (!hasData) {
+    container.innerHTML = "<div style='text-align:center'><b>No bin data available</b></div>";
+    return;
+  }
+
+  const trace = {
+    type: "heatmap",
+    x: xLabels,
+    y: yLabels,
+    z: zMatrix,
+    customdata: nCellMatrix,
+    colorscale: "Viridis",
+    zmin: 0,
+    zmax: 100,
+    colorbar: {
+      title: {
+        text: "Passing (%)",
+      },
+      ticksuffix: "%",
+    },
+    hovertemplate: "%{y} | %{x}<br>Passing: %{z:.1f}%<br>n=%{customdata}<extra></extra>",
+    hoverongaps: false,
+  };
+
+  const layout = {
+    autosize: true,
+    dragmode: false,
+    hovermode: "closest",
+    margin: { l: 120, r: 20, t: 20, b: 100 },
+    xaxis: {
+      tickangle: -45,
+      automargin: true,
+      title: { text: "Hash count bin" },
+      fixedrange: true,
+    },
+    yaxis: {
+      automargin: true,
+      title: { text: "Sample" },
+      fixedrange: true,
+    },
+    paper_bgcolor: "rgba(0,0,0,0)",
+    plot_bgcolor: "rgba(0,0,0,0)",
+  };
+
+  const config = {
+    responsive: true,
+    displayModeBar: false,
+    scrollZoom: false,
+    doubleClick: false,
+    displaylogo: false,
+  };
+
+  Plotly.react(container, [trace], layout, config);
 }
 
 // For each hashing barcode, generate a row in the table.
@@ -781,16 +895,34 @@ function generate_hashing_table(data) {
 }
 
 document.addEventListener("DOMContentLoaded", function () {
-  generate_hashing_summary_table(data.hashing_summary || []);
+  const binLabels = data.hashing_summary_bin_labels || [];
+
+  generate_hashing_summary_table("sample-hashing-summary-table", data.hashing_summary || []);
+  generate_hashing_summary_table("sample-hashing-summary-filt-table", data.hashing_summary_filt || []);
+  generate_hashing_bins_heatmap(data.hashing_summary_bins || [], binLabels);
   generate_hashing_table(data.hashing);
 
   $("#sample-hashing-summary-table").tablesorter({
+    sortList: [[1, 0]],
+  });
+  $("#sample-hashing-summary-filt-table").tablesorter({
     sortList: [[1, 0]],
   });
 
   $("#sample-hashing-table").tablesorter({
     sortList: [[0, 0]],
   });
+
+  // Plotly can be initialized while the Hashing tab is hidden; force a resize when shown.
+  const hashingTabToggle = document.querySelector('a[href="#tabs-hashing"]');
+  if (hashingTabToggle && typeof Plotly !== "undefined") {
+    hashingTabToggle.addEventListener("shown.bs.tab", function () {
+      const heatmap = document.getElementById("chart-hashing-bins-heatmap");
+      if (heatmap) {
+        Plotly.Plots.resize(heatmap);
+      }
+    });
+  }
 
 });
 


### PR DESCRIPTION
- modify ratio definition: if no second hash assume 1 to get a value for ratio of first to second, previously this was NA
- add filtered version of hashing summary only including cells where first hash count has umi >=5
- add histogram of this filtered data showing fraction with ratio >= 3 vs hash count bin for each sample