### PR TITLE
Scale STAR rule memory requirements based on number of reads

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,13 +7,12 @@ Please see the set-up instructions below for more information on how to install 
 
 ## Pre-requirements
 
-> There is currently no LSF support yet in latest snakemake (v8). For LSF clusters (e.g. DKFZ), we recommend using snakemake v7.32.4 instead.
-
-1. A conda system, e.g., [conda](https://docs.conda.io/en/latest/), [mamba](https://mamba.readthedocs.io/en/latest/) or [micromamba](https://micromamba.readthedocs.io/en/latest/)
+1. A conda system, e.g., [conda](https://conda-forge.org/download/)
 2. Snakemake and a cluster-specific Snakemake configuration for batch-job submission (see instructions below).
       * E.g., [LSF](https://github.com/Snakemake-Profiles/lsf) or [SLURM](https://github.com/Snakemake-Profiles/slurm)
 
-We make use of pre-defined environment(s) which houses all software dependencies (`workflow/envs/`). These are installed automatically by Snakemake when running the workflow (`--use-conda`).
+We make use of pre-defined environment(s) which houses all software dependencies (`workflow/rules/envs/`).
+These are installed automatically by Snakemake when running the workflow (`--use-conda`).
 
 ## Set-up
 
@@ -23,13 +22,13 @@ We make use of pre-defined environment(s) which houses all software dependencies
       git clone https://github.com/lauren-saunders-lab/sci-rocket
       ```
 
-2. Download and install snakemake (e.g. using conda or micromamba):
+2. Download and install snakemake using [conda](https://conda-forge.org/download/):
 
       ```bash
-      # This will install snakemake (7.32.4) + Python 3.11.7 into a new conda environment called 'snakemake'
-      micromamba create -c conda-forge -c bioconda -n snakemake snakemake==7.32.4 python==3.11.7 mamba
+      # This will install snakemake, Python and some required libraries into a new conda environment called 'snakemake'
+      conda create -c conda-forge -c bioconda -n snakemake snakemake python mamba pandas numpy
       # Switch to the 'snakemake' environment
-      micromamba activate snakemake
+      conda activate snakemake
       ```
 
 3. Run the workflow:
@@ -45,6 +44,8 @@ We make use of pre-defined environment(s) which houses all software dependencies
 > * `-p`: Print shell commands.
 > * `--notemp`: Do not remove files flagged as temporary.
 > * `--rerun-incomplete`: Rerun all jobs with missing output files.
+> * `--benchmark-extended`: Include requested resources/threads in benchmark files (useful for cluster environments).
+> * `--retries 2`: Retry failed jobs up to 2 times (useful for cluster environments).
 
 ## Configuration
 

--- a/workflow/examples/example_config.yaml
+++ b/workflow/examples/example_config.yaml
@@ -52,6 +52,10 @@ settings:
   star: "--soloMultiMappers EM --outSAMmultNmax 1 --outSAMstrandField intronMotif --outFilterScoreMinOverLread 0.33 --outFilterMatchNminOverLread 0.33 --outSAMunmapped Within --outSAMattributes NH HI AS nM NM MD jM jI MC ch XS CR UR GX GN sM"
   # STARSolo feature set to request (space-separated values, passed to --soloFeatures).
   star_solo_features: "GeneFull_Ex50pAS"
+  # Optional fixed memory override for STARSolo alignment in MB.
+  # If empty, memory is estimated from read counts (~20 bytes/read, minimum 60GB).
+  # On retry attempts, requested memory increases by 50% each time (run snakemake with --retries > 0).
+  star_align_mem_mb: ""
   # Path to bases2fastq executable (if not provided sci-rocket will download it).
   bases2fastq_exe: ""
 

--- a/workflow/rules/scripts/demultiplexing/demux_dash.py
+++ b/workflow/rules/scripts/demultiplexing/demux_dash.py
@@ -1,8 +1,10 @@
 import argparse
+import ast
 import json
 import os
 import pandas as pd
 import pickle
+import re
 import sys
 import pathlib
 
@@ -108,15 +110,87 @@ def resolve_solo_feature_paths(path_star, sample):
     )
 
 
+def _is_missing(value) -> bool:
+    if value is None:
+        return True
+    try:
+        return bool(pd.isna(value))
+    except TypeError:
+        return False
+
+
+def _parse_int_value(value):
+    if _is_missing(value):
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+
+    text = str(value).strip()
+    if text in {"", "-", "NA", "None", "nan"}:
+        return None
+
+    try:
+        parsed = ast.literal_eval(text)
+    except (ValueError, SyntaxError):
+        parsed = None
+
+    if isinstance(parsed, tuple) and len(parsed) == 1:
+        parsed = parsed[0]
+    if isinstance(parsed, (int, float)):
+        return int(parsed)
+    if isinstance(parsed, str):
+        text = parsed.strip()
+
+    match = re.search(r"-?\d+", text)
+    return int(match.group(0)) if match else None
+
+
+def _parse_mem_mb_from_resources(value):
+    if _is_missing(value):
+        return None
+
+    resources = None
+    if isinstance(value, dict):
+        resources = value
+    else:
+        text = str(value).strip()
+        if text in {"", "-", "NA", "None", "nan"}:
+            return None
+        try:
+            parsed = ast.literal_eval(text)
+        except (ValueError, SyntaxError):
+            parsed = None
+
+        if isinstance(parsed, dict):
+            resources = parsed
+        else:
+            match = re.search(r"mem_mb['\"]?\s*[:=]\s*([0-9]+)", text)
+            if match:
+                return int(match.group(1))
+            return None
+
+    return _parse_int_value(resources.get("mem_mb"))
+
+
 def get_benchmarks(path_benchmarks) -> list[dict]:
     frames = []
-    for path in sorted(pathlib.Path(path_benchmarks).glob("*.txt")) + sorted(pathlib.Path(path_benchmarks).parent.glob("*.txt")):
+    path_benchmarks = pathlib.Path(path_benchmarks)
+    for path in sorted(path_benchmarks.glob("*.txt")) + sorted(path_benchmarks.parent.glob("*.txt")):
         df = pd.read_csv(path, sep="\t")
         df.insert(0, "job", path.stem)
         frames.append(df)
     if not frames:
         return []
+
     df = pd.concat(frames, ignore_index=True, sort=False)
+    df["requested_mem_mb"] = None
+    df["requested_threads"] = None
+
+    if "resources" in df.columns:
+        df["requested_mem_mb"] = df["resources"].apply(_parse_mem_mb_from_resources)
+    if "threads" in df.columns:
+        df["requested_threads"] = df["threads"].apply(_parse_int_value)
+
     return df.to_dict('records')
 
 

--- a/workflow/rules/step3_alignment.smk
+++ b/workflow/rules/step3_alignment.smk
@@ -6,6 +6,10 @@
 #   4. sambamba_index:                  Indexing BAM files.
 #############
 
+import math
+import pickle
+
+
 rule trim_fastp:
     input:
         R1=out("{experiment_name}/demux_reads/{sample_name}_R1.fastq.gz"),
@@ -47,6 +51,35 @@ def get_species_qc_pickles_for_index(species):
     experiments = sorted(samples_unique.query("species == @species")["experiment_name"].unique())
     return [out(f"{experiment_name}/demux_reads/{experiment_name}_qc.pickle") for experiment_name in experiments]
 
+def get_star_align_mem_mb(wildcards, input, attempt=1):
+    # default memory requirement of 60 GB, sufficient for most samples with up to hundreds of millions of reads.
+    min_mem_mb = 60 * 1024
+    # for very large numbers (billions) of reads, the solo counting step in STARsolo dominates the memory usage.
+    # with the default STARsolo settings in the pipeline, each mapped read requires ~17 bytes.
+    # assuming 1 mapped read per input read and adding some buffer we require 20 bytes per read:
+    bytes_per_read = 20
+    # in case the step fails, we will increase the memory by a factor of 1.5 for each retry attempt:
+    retry_multiplier = 1.5
+    attempt = max(1, int(attempt))
+    configured = config["settings"].get("star_align_mem_mb", "")
+
+    if configured not in ("", None):
+        base_mem_mb = int(configured)
+        if base_mem_mb <= 0:
+            raise ValueError("settings.star_align_mem_mb must be > 0")
+    else:
+        try:
+            with open(input.demux_qc, "rb") as handle:
+                qc = pickle.load(handle)
+            n_reads = int(qc["sample_success"][wildcards.sample_name]["n_pairs_success"])
+        except (FileNotFoundError, KeyError, ValueError, TypeError, pickle.PickleError):
+            base_mem_mb = min_mem_mb
+        else:
+            estimated_mem_mb = math.ceil((n_reads * bytes_per_read) / (1024 * 1024))
+            base_mem_mb = max(min_mem_mb, estimated_mem_mb)
+
+    return math.ceil(base_mem_mb * (retry_multiplier ** (attempt - 1)))
+
 
 rule generate_index_STAR:
     input:
@@ -85,6 +118,7 @@ rule starSolo_align:
     input:
         R1=out("{experiment_name}/fastp/{sample_name}_R1.fastq.gz"),
         R2=out("{experiment_name}/fastp/{sample_name}_R2.fastq.gz"),
+        demux_qc=out("{experiment_name}/demux_reads/{experiment_name}_qc.pickle"),
         index=out("resources/index_star/{species}/"),
         whitelist_p7=out("{experiment_name}/demux_reads/{experiment_name}_whitelist_p7.txt"),
         whitelist_p5=out("{experiment_name}/demux_reads/{experiment_name}_whitelist_p5.txt"),
@@ -94,10 +128,8 @@ rule starSolo_align:
         bam=out("{experiment_name}/alignment/{sample_name}_{species}_Aligned.sortedByCoord.out.bam"),
         sj=out("{experiment_name}/alignment/{sample_name}_{species}_SJ.out.tab"),
         log1=out("{experiment_name}/alignment/{sample_name}_{species}_Log.final.out"),
-        log2=temp(out("{experiment_name}/alignment/{sample_name}_{species}_Log.out")),
-        log3=temp(
-            out("{experiment_name}/alignment/{sample_name}_{species}_Log.progress.out")
-        ),
+        log2=out("{experiment_name}/alignment/{sample_name}_{species}_Log.out"),
+        log3=out("{experiment_name}/alignment/{sample_name}_{species}_Log.progress.out"),
         dir_tmp=temp(
             directory(out("{experiment_name}/alignment/{sample_name}_{species}__STARtmp"))
         ),
@@ -108,7 +140,7 @@ rule starSolo_align:
         out("logs/step3_alignment/star_align_{experiment_name}_{sample_name}_{species}.log"),
     threads: 30
     resources:
-        mem_mb=1024 * 60,
+        mem_mb=get_star_align_mem_mb,
     benchmark:
         out("benchmarks/{experiment_name}/starSolo_align_{sample_name}_{species}.txt")
     params:

--- a/workflow/scirocket-dash/js/sci_dash.js
+++ b/workflow/scirocket-dash/js/sci_dash.js
@@ -942,6 +942,8 @@ function generate_benchmarks_table(benchmarks) {
       <thead>
         <tr>
           <th>Job</th>
+          <th>Requested RAM<br><sub>(gb)</sub></th>
+          <th>Requested Cores</th>
           <th>Time<br><sub>(seconds)</sub></th>
           <th>Time<br><sub>(h:m:s)</sub></th>
           <th>Max RAM<br><sub>(gb)</sub></th>
@@ -959,7 +961,7 @@ function generate_benchmarks_table(benchmarks) {
   if (!Array.isArray(benchmarks) || benchmarks.length === 0) {
     const row = tbody.insertRow(-1);
     const cell = row.insertCell(0);
-    cell.colSpan = 7;
+    cell.colSpan = 9;
     cell.style.textAlign = "center";
     cell.innerHTML = "<b>No benchmark data available</b>";
     return;
@@ -980,6 +982,10 @@ function generate_benchmarks_table(benchmarks) {
 
     // Job name
     row.insertCell(-1).textContent = b.job ?? "N/A";
+
+    // Requested resources
+    row.insertCell(-1).textContent = fmt_number(b.requested_mem_mb, 2, 1024);
+    row.insertCell(-1).textContent = fmt_number(b.requested_threads, 0);
 
     // Time (seconds)
     row.insertCell(-1).textContent = fmt_number(b.s, 0);
@@ -1003,7 +1009,7 @@ document.addEventListener("DOMContentLoaded", function () {
   generate_benchmarks_table(data.benchmarks);
 
   $("#benchmarks-table").tablesorter({
-    sortList: [[1, 1]],  // default: seconds descending
+    sortList: [[3, 1]],  // default: seconds descending
   });
 });
 


### PR DESCRIPTION
- keep current value of 60GB as the minimum
  - this is fine for most samples (up to 100's of millions of reads)
- for very large number of reads, the solo counting step dominates RAM use
  - this requires some number of bytes of RAM per mapped read
  - in this example ~40 bytes / read: https://github.com/alexdobin/STAR/issues/1577#issuecomment-1153266973
  - for the default parameters in the workflow it is ~17 bytes / read
  - we assume 20 bytes / read, and if this is larger than 60GB then we use this instead
- if the STAR step fails and user has enabled `--retry` when running snakemake
  - increase requested RAM by 50% with each new attempt
- add requested ram/cores to benchmarks table in dashboard
  - user needs to run with `--benchmark-extended` for this information to be available
- don't mark STAR logs as temp to avoid them being deleted at the end of the run
- resolves #47