### PR TITLE
Automatically determine `--sjdbOverhang`

### DIFF
--- a/tests/integration/aviti/tests/test_demux.py
+++ b/tests/integration/aviti/tests/test_demux.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import pickle
 import pytest
 
 
@@ -8,3 +9,18 @@ def test_demux_output_files_exist(sample: str):
     assert demux_path.exists()
     assert (demux_path / f"{sample}_R1.fastq.gz").exists()
     assert (demux_path / f"{sample}_R2.fastq.gz").exists()
+
+
+@pytest.mark.parametrize("experiment", ["fastq_from_aviti_one_run", "fastq_from_aviti_two_runs"])
+def test_qc_pickle_has_expected_max_r2_read_length(experiment: str):
+    test_root = Path(__file__).parent.parent
+    experiment_path = test_root / "output" / experiment
+    demux_path = experiment_path / "demux_reads"
+    path_qc = demux_path / f"{experiment}_qc.pickle"
+
+    assert path_qc.exists()
+
+    with open(path_qc, "rb") as handle:
+        qc = pickle.load(handle)
+
+    assert qc["max_r2_read_length"] == 128

--- a/tests/integration/bcl/tests/test_demux.py
+++ b/tests/integration/bcl/tests/test_demux.py
@@ -206,6 +206,7 @@ def test_qc_pickle_consistent_with_demux_outputs():
     assert qc["sample_success"]["zfish-hash"]["n_pairs_success"] == qc["n_pairs_success"]
     assert n_sample_r1 + qc["n_hashing"] == qc["n_pairs_success"]
     assert n_sample_r1 + n_discard_r1 + qc["n_hashing"] == qc["n_pairs"]
+    assert qc["max_r2_read_length"] == 84
 
 
 def test_qc_pickle_covers_all_samples_from_samplesheet():

--- a/tests/unit/demultiplexing/test_demux_gather.py
+++ b/tests/unit/demultiplexing/test_demux_gather.py
@@ -1,0 +1,40 @@
+from workflow.rules.scripts.demultiplexing.demux_gather import combine_pickle
+
+
+def test_combine_pickle_keeps_max_r2_read_length():
+    combined = {
+        "experiment_name": "exp",
+        "version": "0.0.0",
+        "max_r2_read_length": 84,
+    }
+    incoming = {
+        "experiment_name": "exp",
+        "version": "0.0.0",
+        "max_r2_read_length": 101,
+    }
+
+    merged = combine_pickle(incoming, combined)
+    assert merged["max_r2_read_length"] == 101
+
+    incoming_smaller = {
+        "experiment_name": "exp",
+        "version": "0.0.0",
+        "max_r2_read_length": 90,
+    }
+    merged = combine_pickle(incoming_smaller, merged)
+    assert merged["max_r2_read_length"] == 101
+
+
+def test_combine_pickle_sets_max_r2_read_length_if_missing():
+    combined = {
+        "experiment_name": "exp",
+        "version": "0.0.0",
+    }
+    incoming = {
+        "experiment_name": "exp",
+        "version": "0.0.0",
+        "max_r2_read_length": 92,
+    }
+
+    merged = combine_pickle(incoming, combined)
+    assert merged["max_r2_read_length"] == 92

--- a/workflow/examples/example_config.yaml
+++ b/workflow/examples/example_config.yaml
@@ -37,17 +37,15 @@ species:
 # --- 2. Custom tool settings ----#
 
 # Custom settings for various major steps of the workflow.
-# Important: (star_index): Change the --sjdbOverhang parameter to the read length of R2 (i.e. the read containing the cDNA sequence) - 1.
-# Important: (star_index): For example, if R2 is 84bp long, then --sjdbOverhang should be set to 83.
 settings:
-  # Number of splitted .fastq.gz files to generate per sequencing run to parallize the demultiplexing.
+  # Number of split .fastq.gz files to generate per sequencing run to parallize the demultiplexing.
   scatter_fastq_split: 10
   # Custom settings for bcl2fastq.
   bcl2fastq: "--barcode-mismatches 1 --ignore-missing-positions --ignore-missing-controls --ignore-missing-filter --ignore-missing-bcls --no-lane-splitting --minimum-trimmed-read-length 15 --mask-short-adapter-reads 15"
   # Custom settings for fastp.
   fastp: "--detect_adapter_for_pe --qualified_quality_phred 15 --dont_eval_duplication --length_required 10"
-  # Custom settings for STAR genome preparation.
-  star_index: "--sjdbOverhang 83"
+  # Custom settings for STAR genome preparation (if empty, sci-rocket will set this to `--sjdbOverhang <R2_read_length - 1>`)
+  star_index: ""
   # Custom settings for STARSolo alignment.
   star: "--soloMultiMappers EM --outSAMmultNmax 1 --outSAMstrandField intronMotif --outFilterScoreMinOverLread 0.33 --outFilterMatchNminOverLread 0.33 --outSAMunmapped Within --outSAMattributes NH HI AS nM NM MD jM jI MC ch XS CR UR GX GN sM"
   # STARSolo feature set to request (space-separated values, passed to --soloFeatures).

--- a/workflow/rules/scripts/demultiplexing/demux_gather.py
+++ b/workflow/rules/scripts/demultiplexing/demux_gather.py
@@ -58,6 +58,8 @@ def combine_pickle(pickle_dict, combined_dict):
                 else:
                     for index, count in pickle_dict["rt_barcode_counts"][plate].items():
                         combined_dict["rt_barcode_counts"][plate][index] = combined_dict["rt_barcode_counts"][plate].get(index, 0) + count
+        elif key == "max_r2_read_length":
+            combined_dict[key] = max(combined_dict.get(key, 0), pickle_dict[key])
 
         # Merge everything else.
         else:

--- a/workflow/rules/scripts/demultiplexing/demux_rocket.py
+++ b/workflow/rules/scripts/demultiplexing/demux_rocket.py
@@ -122,6 +122,7 @@ def init_qc(experiment_name: str, dict_barcodes: dict, samples: pd.DataFrame, di
     qc["n_pairs"] = 0  # Total number of initial read-pairs.
     qc["n_pairs_success"] = 0  # Total number of read-pairs with correct RT, p5, p7 and ligation barcodes.
     qc["n_pairs_failure"] = 0  # Total number of discarded read-pairs due to various reason.
+    qc["max_r2_read_length"] = 0  # Maximum observed R2 read length.
 
     qc["n_corrected_p5"] = 0  # Total number of read-pairs with 1bp mismatch in p5.
     qc["n_corrected_p7"] = 0  # Total number of read-pairs with 1bp mismatch in p7.
@@ -196,6 +197,7 @@ def update_qc(qc:dict, x:sciRecord):
 
     # Update the total number of read-pairs processed.
     qc["n_pairs"] += 1
+    qc["max_r2_read_length"] = max(qc["max_r2_read_length"], len(x.read2.sequence))
 
     # Update the number of read-pairs with correct barcodes.
     # Also count the hashing reads for this.

--- a/workflow/rules/scripts/demultiplexing/get_star_index_overhang.py
+++ b/workflow/rules/scripts/demultiplexing/get_star_index_overhang.py
@@ -1,0 +1,45 @@
+import argparse
+import pickle
+
+
+def get_star_index_args(star_index_extra: str, path_qc_pickles: list[str]) -> str:
+    extra = star_index_extra.strip()
+    if extra:
+        return extra
+
+    if not path_qc_pickles:
+        raise ValueError("No demux QC pickles provided to infer --sjdbOverhang.")
+
+    max_len = 0
+    for path_qc in path_qc_pickles:
+        with open(path_qc, "rb") as handle:
+            qc = pickle.load(handle)
+        max_len = max(max_len, int(qc["max_r2_read_length"]))
+
+    if max_len <= 1:
+        raise ValueError(f"Invalid max_r2_read_length ({max_len}) across QC pickles.")
+
+    return f"--sjdbOverhang {max_len - 1}"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Return STAR genomeGenerate args, computing --sjdbOverhang from QC when needed."
+    )
+    parser.add_argument(
+        "--star-index-extra",
+        default="",
+        help="Raw settings.star_index value from config; if set, returned unchanged.",
+    )
+    parser.add_argument(
+        "path_qc_pickles",
+        nargs="*",
+        help="Demultiplexing QC pickle paths used to infer max R2 read length.",
+    )
+    args = parser.parse_args()
+
+    print(get_star_index_args(args.star_index_extra, args.path_qc_pickles))
+
+
+if __name__ == "__main__":
+    main()

--- a/workflow/rules/step3_alignment.smk
+++ b/workflow/rules/step3_alignment.smk
@@ -6,7 +6,6 @@
 #   4. sambamba_index:                  Indexing BAM files.
 #############
 
-
 rule trim_fastp:
     input:
         R1=out("{experiment_name}/demux_reads/{sample_name}_R1.fastq.gz"),
@@ -42,8 +41,16 @@ def get_star_solo_features():
     configured = config["settings"].get("star_solo_features", "").strip()
     return configured if configured else "GeneFull_Ex50pAS"
 
+def get_species_qc_pickles_for_index(species):
+    if config["species"][species]["star_index"]:
+        return []
+    experiments = sorted(samples_unique.query("species == @species")["experiment_name"].unique())
+    return [out(f"{experiment_name}/demux_reads/{experiment_name}_qc.pickle") for experiment_name in experiments]
+
 
 rule generate_index_STAR:
+    input:
+        qc=lambda w: get_species_qc_pickles_for_index(w.species),
     output:
         directory(out("resources/index_star/{species}")),
     log:
@@ -57,7 +64,8 @@ rule generate_index_STAR:
         fasta=lambda w: config["species"][w.species]["genome"],
         gtf=lambda w: config["species"][w.species]["genome_gtf"],
         star_index=lambda w: config["species"][w.species]["star_index"],
-        extra=config["settings"]["star_index"],
+        star_index_extra=config["settings"]["star_index"],
+        star_overhang_script=f"{workflow.basedir}/rules/scripts/demultiplexing/get_star_index_overhang.py",
     conda:
         "envs/sci-rocket.yaml",
     message: "Generating (or symlinking) STAR indexes."
@@ -67,7 +75,8 @@ rule generate_index_STAR:
         if [ -n "{params.star_index}" ]; then
             ln -s "$(realpath "{params.star_index}")" "{output}"
         else
-            STAR {params.extra} --runThreadN {threads} --runMode genomeGenerate --genomeFastaFiles {params.fasta} --genomeDir {output} --sjdbGTFfile {params.gtf} >& {log}
+            ARGS=$(python "{params.star_overhang_script}" --star-index-extra "{params.star_index_extra}" {input.qc})
+            STAR $ARGS --runThreadN {threads} --runMode genomeGenerate --genomeFastaFiles {params.fasta} --genomeDir {output} --sjdbGTFfile {params.gtf} >& {log}
         fi
         """
 


### PR DESCRIPTION
- if `settings.star_index` is empty
  - pass `--sjdbOverhang N` to STAR, where N is the max R2 read length minus one
  - users no longer have to set this manually
- if it is set, then pass whatever is there instead
  - maintains existing behaviour for existing configs