### PR TITLE
Allow sequencer lanes to be specified

### DIFF
--- a/docs/overview_files.md
+++ b/docs/overview_files.md
@@ -8,6 +8,7 @@ See [example sample-sheet](https://github.com/lauren-saunders-lab/sci-rocket/blo
   * Multiple paths can be specified separated by semicolons (e.g. `path_reads1;path_reads2`), if the sample is sequenced across multiple runs.
   * If the path contains BCL files, `bcl2fastq` will be run internally to generate the fastq files.
   * If the path contains AVITI files, `Bases2Fastq` and `fastq-fix-i5` will be run internally to generate the fastq files in Illumina (p5 RC) format.
+  * If only selected sequencing lanes are available, lane restriction can be configured in `config.yaml` via `settings.sequencing_lanes` using a comma-delimited list (e.g. `1,2`).
   * If the path contains fastq.gz files, these must be in Illumina (p5 RC) format.
 * **experiment_name**: Experiment name (e.g., experimentXYZ), used to associate all downstream files and underlying samples.
 * **p5**: PCR (p5) index(es) (e.g. A01:H01, or **column(s)** of a 96-well index plate) used to identify the sample during demultiplexing.

--- a/tests/unit/demultiplexing/test_preprocess.py
+++ b/tests/unit/demultiplexing/test_preprocess.py
@@ -114,3 +114,34 @@ def test_get_samples_ignores_comment_lines(test_config: dict):
 
     assert len(samples) == 2
     assert set(samples["sample_name"]) == {"sample1", "sample2"}
+
+
+@pytest.mark.parametrize(
+    "lane_config,expected",
+    [
+        (None, None),
+        ("", None),
+        ("2", ["2"]),
+        ("1,2", ["1", "2"]),
+        ("1, 2, 03", ["1", "2", "3"]),
+    ],
+)
+def test_parse_sequencing_lanes_valid(lane_config, expected):
+    assert preprocess.parse_sequencing_lanes(lane_config) == expected
+
+
+@pytest.mark.parametrize("lane_config", ["A", "0", "1+B", "1,,2", [1, 2], 2, {"x": 1}])
+def test_parse_sequencing_lanes_invalid(lane_config):
+    with pytest.raises(ValueError):
+        preprocess.parse_sequencing_lanes(lane_config)
+
+
+def test_get_configured_sequencing_lanes_global_setting():
+    config = {"settings": {"sequencing_lanes": "2,3"}}
+    assert preprocess.get_configured_sequencing_lanes(config) == ["2", "3"]
+
+
+def test_get_configured_sequencing_lanes_dict_is_invalid():
+    config = {"settings": {"sequencing_lanes": {"default": "2", "run2": "3+4"}}}
+    with pytest.raises(ValueError):
+        preprocess.get_configured_sequencing_lanes(config)

--- a/workflow/examples/example_config.yaml
+++ b/workflow/examples/example_config.yaml
@@ -42,6 +42,8 @@ settings:
   scatter_fastq_split: 10
   # Custom settings for bcl2fastq.
   bcl2fastq: "--barcode-mismatches 1 --ignore-missing-positions --ignore-missing-controls --ignore-missing-filter --ignore-missing-bcls --no-lane-splitting --minimum-trimmed-read-length 15 --mask-short-adapter-reads 15"
+  # Optional comma-delimited list of lane IDs for BCL/Bases2Fastq conversion. If empty, BCL uses all lanes, AVITI defaults to 1+2.
+  sequencing_lanes: ""
   # Custom settings for fastp.
   fastp: "--detect_adapter_for_pe --qualified_quality_phred 15 --dont_eval_duplication --length_required 10"
   # Custom settings for STAR genome preparation (if empty, sci-rocket will set this to `--sjdbOverhang <R2_read_length - 1>`)

--- a/workflow/rules/scripts/demultiplexing/preprocess.py
+++ b/workflow/rules/scripts/demultiplexing/preprocess.py
@@ -1,7 +1,59 @@
 import re
 import logging
 import pandas as pd
-import numpy as np
+
+def parse_sequencing_lanes(lane_config) -> list[str] | None:
+    """
+    Parse a lane configuration value into a normalized list of lane IDs.
+
+    Accepted format:
+        - str (e.g., "2" or "1,2,3")
+
+    Returns:
+        list[str] | None: Unique lane IDs in input order, or None if unset/blank.
+    """
+    if lane_config is None:
+        return None
+
+    if not isinstance(lane_config, str):
+        raise ValueError(
+            f"Invalid sequencing lane config type: {type(lane_config).__name__}. "
+            "Expected a comma-delimited string, e.g. '1,2'."
+        )
+
+    lane_config = lane_config.strip()
+    if not lane_config:
+        return None
+
+    lanes = []
+    for token in lane_config.split(","):
+        lane = token.strip()
+        if not lane:
+            raise ValueError(
+                "Invalid sequencing lanes format: empty lane token found. "
+                "Expected a comma-delimited list such as '1,2'."
+            )
+        if not lane.isdigit() or int(lane) < 1:
+            raise ValueError(
+                f"Invalid sequencing lane '{lane}'. Expected positive integer lane IDs."
+            )
+        normalized_lane = str(int(lane))
+        if normalized_lane not in lanes:
+            lanes.append(normalized_lane)
+
+    return lanes or None
+
+
+def get_configured_sequencing_lanes(config: dict) -> list[str] | None:
+    """
+    Return globally configured lane IDs from config.settings.
+
+    Supports:
+        settings.sequencing_lanes: "2" / "1,2"
+    """
+    settings = config.get("settings", {})
+    lane_config = settings.get("sequencing_lanes", None)
+    return parse_sequencing_lanes(lane_config)
 
 def init_logger():
     """

--- a/workflow/rules/step1_reads2fastq.smk
+++ b/workflow/rules/step1_reads2fastq.smk
@@ -4,14 +4,36 @@
 #   2. reads2fastq:                   Convert bcl to fastq with p5 and p7 indexes within the read name.
 #############
 
-from pathlib import Path
-
-
 def get_path(sequencing_name, experiment_name):
     """
     Return the path to the reads for a given sequencing run.
     """
     return samples_unique.query("sequencing_name == @sequencing_name & experiment_name == @experiment_name").path_reads.values[0]
+
+
+def get_sequencing_lanes():
+    """
+    Return optional globally configured lane IDs.
+    """
+    return preprocess.get_configured_sequencing_lanes(config)
+
+
+def get_fake_bcl_samplesheet():
+    """
+    Build fake BCL sample-sheet contents, with optional lane restriction.
+    """
+    lanes = get_sequencing_lanes()
+    rows = [f"{lane},fake,fake,NNNNNNNNNN,NNNNNNNNNN" for lane in lanes] if lanes else [",fake,fake,NNNNNNNNNN,NNNNNNNNNN"]
+    return "[DATA]\nLane,Sample_ID,Sample_Name,index,index2\n" + "\n".join(rows) + "\n"
+
+
+def get_fake_aviti_manifest():
+    """
+    Build fake AVITI run-manifest contents, with optional lane restriction.
+    """
+    lanes = get_sequencing_lanes()
+    lane_field = "+".join(lanes) if lanes else "1+2"
+    return f"[Samples]\nSampleName,Index1,Index2,Lane\nfake,AAAAAAAAAA,AAAAAAAAAA,{lane_field}\n"
 
 
 rule install_bases2fastq:
@@ -61,6 +83,9 @@ rule reads2fastq:
     params:
         path_out=out("{experiment_name}/raw_reads/{sequencing_name}"),
         extra=config["settings"]["bcl2fastq"],
+        lanes=lambda _: ",".join(get_sequencing_lanes() or []),
+        fake_bcl_samplesheet=lambda _: get_fake_bcl_samplesheet(),
+        fake_aviti_manifest=lambda _: get_fake_aviti_manifest(),
     conda:
         "envs/sci-rocket.yaml",
     message: "Converting reads to fastq with p5 and p7 indexes within the read name ({wildcards.experiment_name}: {wildcards.sequencing_name})."
@@ -72,7 +97,14 @@ rule reads2fastq:
         if [[ -f "{input.path}/RunInfo.xml" ]]; then
             echo "Found RunInfo.xml in {input.path}: treating input as BCL run folder."
             echo "Running bcl2fastq to convert to fastq.gz"
-            echo -e "[DATA]\nLane,Sample_ID,Sample_Name,index,index2\n,fake,fake,NNNNNNNNNN,NNNNNNNNNN" > "{params.path_out}/fake_bcl_sample_sheet.csv"
+            if [[ -n "{params.lanes}" ]]; then
+                echo "Restricting BCL conversion to lane(s): {params.lanes}"
+            else
+                echo "No lane restriction configured; using all lanes."
+            fi
+            cat > "{params.path_out}/fake_bcl_sample_sheet.csv" << 'EOF_BCL'
+{params.fake_bcl_samplesheet}
+EOF_BCL
             # 40 cores / 40GB RAM: 2GB/core needed according to Illumina bcl2fastq docs
             bcl2fastq \
             {params.extra} \
@@ -85,7 +117,14 @@ rule reads2fastq:
         elif [[ -d "{input.path}/BaseCalls" ]]; then
             echo "Found BaseCalls/ in {input.path} (and no RunInfo.xml): treating input as AVITI run folder"
             echo "Running Bases2Fastq to convert to fastq.gz, then using fastq-fix-i5 to reverse-complement i5 in R1 headers"
-            echo -e "[Samples]\nSampleName,Index1,Index2,Lane\nfake,AAAAAAAAAA,AAAAAAAAAA,1+2\n" > "{params.path_out}/fake_aviti_run_manifest.csv"
+            if [[ -n "{params.lanes}" ]]; then
+                echo "Restricting AVITI conversion to lane(s): {params.lanes}"
+            else
+                echo "No lane restriction configured; defaulting AVITI lane field to 1+2."
+            fi
+            cat > "{params.path_out}/fake_aviti_run_manifest.csv" << 'EOF_AVITI'
+{params.fake_aviti_manifest}
+EOF_AVITI
             # 8 cores / 48GB RAM: 6GB/core needed according to https://docs.elembio.io/docs/bases2fastq/setup/#memory-and-performance
             {input.bases2fastq_exe} \
             --run-manifest "{params.path_out}/fake_aviti_run_manifest.csv" \


### PR DESCRIPTION
- add `sequencing_lanes` to config settings
- takes a comma-delimited list of lanes, e.g. "1,2"
- if empty, existing behaviour is preserved:
  - all lanes for BCL
  - lanes 1+2 for AVITI
- resolves #33